### PR TITLE
feat&fix&pref: 调整布局；新增功能；优化细节。

### DIFF
--- a/entry/src/main/ets/For_2in1_UI/FOR2IN1.ets
+++ b/entry/src/main/ets/For_2in1_UI/FOR2IN1.ets
@@ -130,16 +130,15 @@ export struct IS_2IN1_UI{
   TitleBar(){
     Column(){
       // PC工具栏适配
-      if(this.topRect > 0){
-        Row()
+      Row()
         .height(this.topRect)
         .width('100%')
-      }
-      if(this.decorHeight > 0){
-        Row()
+        .visibility(this.topRect > 0 ? Visibility.Visible : Visibility.None)
+
+      Row()
         .height(this.decorHeight)
         .width('100%')
-      }
+        .visibility(this.decorHeight > 0 ? Visibility.Visible : Visibility.None)
 
       Row() {
         Row()
@@ -167,7 +166,7 @@ export struct IS_2IN1_UI{
       .alignItems(VerticalAlign.Center)
       .height(50)
     }
-    .height(this.topRect+50+this.decorHeight)
+    .height(this.topRect+StyleConstants.TITLE_HEIGHT+this.decorHeight)
   }
 
   @Builder
@@ -250,17 +249,16 @@ export struct IS_2IN1_UI{
           SideBarContainer(this.currentBreakpoint === 'sm' ? SideBarContainerType.Overlay : SideBarContainerType.Embed){
             Column(){
               Column(){
-                if(this.topRect > 0){
-                  Row(){}
+                Row()
                   .height(this.topRect)
-                }
-                if(this.decorHeight > 0){
-                  Row(){
-                  }
+                  .visibility(this.topRect > 0 ? Visibility.Visible : Visibility.None)
+
+                Row()
                   .justifyContent(FlexAlign.Start)
                   .alignItems(VerticalAlign.Center)
                   .height(this.decorHeight)
-                }
+                  .visibility(this.decorHeight > 0 ? Visibility.Visible : Visibility.None)
+
                 Row()
                   .height(StyleConstants.TITLE_HEIGHT)
               }

--- a/entry/src/main/ets/For_2in1_UI/FOR2IN1.ets
+++ b/entry/src/main/ets/For_2in1_UI/FOR2IN1.ets
@@ -8,19 +8,15 @@ import { MiniPlaybackControl } from '../component/MiniPlaybackControl';
 import { Setting_2in1 } from './Setting_for2in1';
 import { MenuIcon } from '../component/MenuIcon';
 
-@Builder
-export function FOR_2IN1_UI(){
-  IS_2IN1_UI()
-}
 @Component
 export struct IS_2IN1_UI{
   @StorageProp('decorHeight') decorHeight: number = 0
   @Consume('NavPathStack') pageStack: NavPathStack;
   @StorageLink('user_playlist') playlists: Playlist[] = [];
   @StorageLink('currentBreakpoint') currentBreakpoint: string = 'sm'
-  @State page_judge: string = 'index'
+  @Link page_judge: string
   @State sidebar_ctrl: boolean = false
-  @State title: string = '首页'
+  @Link title: string
   @StorageProp('bottomRect') bottomRect: number = 0
   @StorageProp('topRect') topRect: number = 0
   uiContext: UIContext | undefined = undefined;
@@ -123,7 +119,7 @@ export struct IS_2IN1_UI{
     .alignItems(VerticalAlign.Center)
     .backgroundColor(Color.Transparent)
     .height(StyleConstants.TITLE_HEIGHT)
-    .width(300)
+    .width(this.sidebar_ctrl ? 300 : 100)
     .animation({
       duration: 250,
       curve: Curve.FastOutSlowIn
@@ -325,14 +321,14 @@ export struct IS_2IN1_UI{
                 }
                 .backgroundColor($r('app.color.page_background'))
                 Stack(){
-                  Index_page()//index_2in1 等待适配
-                  if (this.page_judge === 'Setting'){
+                  if(this.page_judge === 'index'){
+                    Index_page()//index_2in1 等待适配
+                  }else if (this.page_judge === 'Setting'){
                     Setting_2in1()
                   }else if (this.page_judge === 'playlist'){
                     PlayListFor2in1()
                   }
                 }
-
               }
               .zIndex(1)
               .scale(this.sidebar_ctrl && this.currentBreakpoint === 'sm' ? { x: 0.95, y: 0.95 } : {})

--- a/entry/src/main/ets/For_2in1_UI/Index_2in1.ets
+++ b/entry/src/main/ets/For_2in1_UI/Index_2in1.ets
@@ -40,7 +40,7 @@ export struct Index_page {
   @StorageProp('bottomRect') bottomRect: number = 0
   @StorageProp('topRect') topRect: number = 0
   @StorageProp('winHeight') winHeight: number = 0
-  @State HorizontalMode_ctrl: string = PreferencesCache.getUserPreference('HorizontalMode_ctrl', '0')
+  @State HorizontalMode_ctrl: string = PreferencesCache.getUserPreference('HorizontalMode_ctrl', '1')
   @State scrollController: ScrollController = new ScrollController({
     onIndexChange: (index) => {
       this.onMenuIconClick(index)

--- a/entry/src/main/ets/For_2in1_UI/Index_2in1.ets
+++ b/entry/src/main/ets/For_2in1_UI/Index_2in1.ets
@@ -176,27 +176,26 @@ export struct Index_page {
 
     Column(){
       // PC工具栏适配
-      if(this.topRect > 0){
-        Row(){}
+      Row()
         .height(this.topRect)
         .backgroundColor('transparent')
         .width('100%')
+        .visibility(this.topRect > 0 ? Visibility.Visible : Visibility.None)
+
+      Row(){
+        Image($r('app.media.icon'))
+          .height(this.decorHeight/2)
+          .width(this.decorHeight/2)
+          .margin({ left: 16 })
+        Blank().width(5)
+        Text('云享社').fontSize(14).fontWeight(FontWeight.Bold)
       }
-      if(this.decorHeight > 0){
-        Row(){
-          Image($r('app.media.icon'))
-            .height(this.decorHeight/2)
-            .width(this.decorHeight/2)
-            .margin({ left: 16 })
-          Blank().width(5)
-          Text('云享社').fontSize(14).fontWeight(FontWeight.Bold)
-        }
-        .justifyContent(FlexAlign.Start)
-        .alignItems(VerticalAlign.Center)
-        .height(this.decorHeight)
-        .backgroundColor('transparent')
-        .width('100%')
-      }
+      .justifyContent(FlexAlign.Start)
+      .alignItems(VerticalAlign.Center)
+      .height(this.decorHeight)
+      .backgroundColor('transparent')
+      .width('100%')
+      .visibility(this.decorHeight > 0 ? Visibility.Visible : Visibility.None)
 
       Row() {
         Text($r("app.string.homepage"))

--- a/entry/src/main/ets/For_2in1_UI/Index_2in1.ets
+++ b/entry/src/main/ets/For_2in1_UI/Index_2in1.ets
@@ -13,6 +13,8 @@ import { ScrollController } from '../util/ScrollController'
 import { HeaderAnimation } from '../component/HeaderAnimation'
 import { deviceInfo } from '@kit.BasicServicesKit'
 import { avPlayerManager } from '../util/AVPlayerManager';
+import { LogUtil } from '@pura/harmony-utils'
+
 // 缓存常用值以避免重复计算
 const COLUMNS_TEMPLATE_LG = '1fr 1fr 1fr 1fr'
 const COLUMNS_TEMPLATE_SM = '1fr 1fr'
@@ -35,7 +37,7 @@ export struct Index_page {
   @StorageLink("index_recommend_songs") recommendSongs: Song[] = PreferencesCache.getSongCache('index_recommend_songs')
   @StorageLink("index_recommend_artists") recommendArtists: Artist[] = PreferencesCache.getArtistCache('index_recommend_artists')
   @StorageLink("index_recommend_toplist") topList: Playlist[] = PreferencesCache.getPlaylistCache('index_recommend_toplist')
-  @State loading: boolean = true
+  @State loading: boolean = false
   // 避让导航栏高度
   @StorageProp('bottomRect') bottomRect: number = 0
   @StorageProp('topRect') topRect: number = 0
@@ -114,9 +116,6 @@ export struct Index_page {
     this.breakpointSystem.register(this.getUIContext())
     HorizontalMode(this.getUIContext().getHostContext() as Context,this.HorizontalMode_ctrl === '1')
     AppStorage.setOrCreate("pageStack", this.pageStack)
-    // 立即初始化数据
-    // this.initData()
-    this.loading = false
     let productSeries:string=deviceInfo.productSeries
     let devicetype:string =deviceInfo.deviceType
     if (devicetype!='phone'&&productSeries!='VDE'){
@@ -136,21 +135,12 @@ export struct Index_page {
 
   async initData() {
     this.loading = true
-
-    try {
-      // 并行加载数据并捕获异常
-      await Promise.all([
-        SourceAdapter.getRecommendList(this.limit),
-        SourceAdapter.getRecommendSongs(this.limit),
-        SourceAdapter.getRecommendArtists(this.limit),
-        SourceAdapter.getTopList(this.limit),
-        SourceAdapter.getUserPlaylist()
-      ])
-    } catch (error) {
-      console.error('Failed to load data', error)
-    } finally {
+    SourceAdapter.getAllRecommend().then(() => {
+      LogUtil.info(`[${TAG}]`, `首页刷新数据成功`)
+    }).finally(() => {
       this.loading = false
-    }
+    })
+
   }
 
   onPageShow(): void {

--- a/entry/src/main/ets/For_2in1_UI/Index_2in1.ets
+++ b/entry/src/main/ets/For_2in1_UI/Index_2in1.ets
@@ -282,7 +282,7 @@ export struct Index_page {
       onActionClick: async () => {
         this.recommendSongs = await SourceAdapter.getRecommendSongs(this.limit)
       },
-    }).key('Index-R')
+    })
   }
 
   @Builder
@@ -296,7 +296,7 @@ export struct Index_page {
       onActionClick: async () => {
         this.recommendPlaylist = await SourceAdapter.getRecommendList(this.limit)
       },
-    }).key('Index-R')
+    })
   }
 
   @Builder
@@ -311,7 +311,7 @@ export struct Index_page {
       onActionClick: async () => {
         this.recommendArtists = await SourceAdapter.getRecommendArtists(this.limit)
       },
-    }).key('Index-R')
+    })
   }
 
   @Builder
@@ -321,7 +321,7 @@ export struct Index_page {
       type: 'TopPlaylist',
       title: $r('app.string.chart'),
       loading: this.loading
-    }).key('Index-R')
+    })
   }
 
   @Builder

--- a/entry/src/main/ets/For_2in1_UI/Playlist_2in1.ets
+++ b/entry/src/main/ets/For_2in1_UI/Playlist_2in1.ets
@@ -2,7 +2,7 @@ import { AlbumCoversCarousel } from "../component/AlbumCoversCarousel";
 import { SongInfo } from "../component/SongInfo";
 import { TitleHeader } from "../component/TitleHeader";
 import { StyleConstants } from "../constants/StyleConstants";
-import { Playlist, Song } from "../type/Adapter";
+import { Playlist, PlaylistType, Song } from "../type/Adapter";
 import { BasicPrefetcher } from '@kit.ArkUI';
 import { SongDataSourcePrefetching } from "../util/SongDataSourcePrefetching";
 import { BreakpointConstants } from "../constants/BreakpointConstants";
@@ -235,32 +235,57 @@ export struct PlayListFor2in1 {
             ForEach(this.filteredSongs, (song: Song, index: number) => {
               ListItem() {
                 SongInfo({
+                  playlistId: this.playlist?.id,
                   song: song,
                   index: index,
                   active: this.song?.id === song.id,
                   highlight: this.billingIndex === index,
                   onTap: (song: Song) => {
                     this.onSongTap(song, index);
-                  }
+                  },
+                  isShowMenu: true
                 })
               }
               .key(`${song.id}-${index}`)
             })
           } else {
-            ForEach(this.playlist?.songs, (song: Song, index: number) => {
-              ListItem() {
-                SongInfo({
-                  song: song,
-                  index: index,
-                  active: this.song?.id === song.id,
-                  highlight: this.billingIndex === index,
-                  onTap: (song: Song) => {
-                    this.onSongTap(song, index);
-                  }
-                })
-              }
-              .key(`${song.id}-${index}`)
-            }, (song: Song, index: number) => `${song.id}-${index}`)
+            if(this.playlist?.type === PlaylistType.AGGREGATION) {
+              ForEach(this.playlist.songs, (song: Song, index: number) => {
+                ListItem() {
+                  SongInfo({
+                    playlistId: this.playlist?.id,
+                    playlistType: this.playlist?.type,
+                    song: song,
+                    index: index,
+                    active: this.song?.id === song.id,
+                    highlight: this.billingIndex === index,
+                    onTap: (song: Song) => {
+                      this.onSongTap(song, index);
+                    },
+                    isShowMenu: true
+                  })
+                }
+                .key(`${song.id}-${index}`)
+              }, (song: Song, index: number) => `${song.id}-${index}`)
+            } else {
+              LazyForEach(this.songDataSource, (song: Song, index: number) => {
+                ListItem() {
+                  SongInfo({
+                    playlistId: this.playlist?.id,
+                    playlistType: this.playlist?.type,
+                    song: song,
+                    index: index,
+                    active: this.song?.id === song.id,
+                    highlight: this.billingIndex === index,
+                    onTap: (song: Song) => {
+                      this.onSongTap(song, index);
+                    },
+                    isShowMenu: true
+                  })
+                }
+                .key(`${song.id}-${index}`)
+              }, (song: Song, index: number) => `${song.id}-${index}`)
+            }
           }
         }
         .onAreaChange((_oldValue: Area, newValue: Area) => {

--- a/entry/src/main/ets/adapter/index.ets
+++ b/entry/src/main/ets/adapter/index.ets
@@ -464,6 +464,17 @@ export class SourceAdapter {
     }
   }
 
+  static async getAggregationPlaylistDetail(playlist: Playlist): Promise<Playlist> {
+    try {
+      return playlist;
+    } catch (error) {
+      LogUtil.error(TAG, `获取歌单详情失败，id：${playlist.id}，错误：${error}`);
+      // 出错时返回空歌曲列表的歌单
+      playlist.songs = [];
+      return playlist;
+    }
+  }
+
   static async getAlbumDetail(album: Album): Promise<Playlist> {
     try {
       const source = album.source as SourceConfig;
@@ -647,6 +658,21 @@ export class SourceAdapter {
     } catch (error) {
       LogUtil.error(TAG, `收藏歌曲操作失败，歌曲id：${song.id}，错误：${error}`);
       // 不抛出异常，只记录日志
+    }
+  }
+
+  static async getAllRecommend(limit: number = 20): Promise<void>{
+    try {
+      // 并行加载数据并捕获异常
+      await Promise.all([
+        SourceAdapter.getRecommendList(limit),
+        SourceAdapter.getRecommendSongs(limit),
+        SourceAdapter.getRecommendArtists(limit),
+        SourceAdapter.getTopList(limit),
+        SourceAdapter.getUserPlaylist()
+      ])
+    } catch (error) {
+      LogUtil.error(`[${TAG}]`, `Failed to load data: ${error}`, )
     }
   }
 }

--- a/entry/src/main/ets/component/CustomTextBuilder.ets
+++ b/entry/src/main/ets/component/CustomTextBuilder.ets
@@ -1,0 +1,52 @@
+
+@Component
+export struct AddAggregationPlaylist {
+  @Link playlistDesc: string
+  @Link playlistName: string
+
+  build() {
+    Column(){
+      List({ space: 10 }){
+        ListItem(){
+          Column(){
+            Text('歌单名称')
+              .fontSize(16)
+              .fontWeight(700)
+              .margin({ left: 14 })
+            TextInput({ placeholder: '请输入歌单名称', text: this.playlistName })
+              .width('100%')
+              .margin({ top: 5 })
+              .onChange((value: string) => {
+                this.playlistName = value;
+              })
+          }
+          .justifyContent(FlexAlign.Center)
+          .alignItems(HorizontalAlign.Start)
+        }
+
+        ListItem(){
+          Column() {
+            Text('歌单描述')
+              .fontSize(14)
+              .fontWeight(700)
+              .margin({ left: 16 })
+            TextArea({ placeholder: '请输入歌单描述', text: this.playlistDesc })
+              .width('100%')
+              .height(120)
+              .margin({ top: 5 })
+              .onChange((value: string) => {
+                this.playlistDesc = value;
+              })
+          }
+          .justifyContent(FlexAlign.Center)
+          .alignItems(HorizontalAlign.Start)
+        }
+      }
+      .scrollBar(BarState.Off)
+    }
+    .width('100%')
+    .height('auto')
+    .alignItems(HorizontalAlign.Center)
+    .justifyContent(FlexAlign.Center)
+  }
+}

--- a/entry/src/main/ets/component/HorizontalScroll.ets
+++ b/entry/src/main/ets/component/HorizontalScroll.ets
@@ -214,7 +214,7 @@ export struct HorizontalScroll {
           DialogHelper.showSelectDialog({
             title: $r('app.string.add_to_playlist'),
             confirm: $r('app.string.back'),
-            selectedIndex: 0,
+            selectedIndex: -1,
             radioContent: this.aggregationPlaylist.map(playlist => playlist.name),
             onCheckedChanged: (index) => {
               this.selectedIndex = index

--- a/entry/src/main/ets/component/HorizontalScroll.ets
+++ b/entry/src/main/ets/component/HorizontalScroll.ets
@@ -1,4 +1,5 @@
 import { LazyData } from "@pie/lazy-data"
+import { DialogHelper } from "@pura/harmony-dialog"
 import { ToastUtil } from "@pura/harmony-utils"
 import { SourceAdapter } from "../adapter"
 import { StyleConstants } from "../constants/StyleConstants"
@@ -15,12 +16,14 @@ const DEFAULT_COVER_SIZE = 256
 export struct HorizontalScroll {
   @Consume('NavPathStack') pageStack: NavPathStack
   @Prop lists: Object[]
+  @State selectedIndex: number = 0
   type: string = ''
   private coverWidth: number = 120
   private segmentPadding: number = 4
   private radius: string | number = 8
   @StorageLink('2in1title') title:string='首页'
   @StorageLink('2in1page_judge') page_judge:string = 'index'
+  @StorageLink('aggregation_playlist') aggregationPlaylist: Playlist[] = PreferencesCache.getPlaylistCache('aggregation_playlist')
   build() {
     Scroll() {
       Row() {
@@ -203,6 +206,29 @@ export struct HorizontalScroll {
         value: $r('app.string.add_to_play_next'),
         action: () => {
           PlaylistManager.insertSongs([song])
+        }
+      },
+      {
+        value: $r('app.string.add_to_playlist'),
+        action: () => {
+          DialogHelper.showSelectDialog({
+            title: $r('app.string.add_to_playlist'),
+            confirm: $r('app.string.back'),
+            selectedIndex: 0,
+            radioContent: this.aggregationPlaylist.map(playlist => playlist.name),
+            onCheckedChanged: (index) => {
+              this.selectedIndex = index
+              if(PreferencesCache.addSongToAggregationPlaylist(this.aggregationPlaylist[this.selectedIndex], song)){
+                ToastUtil.showShort(`[${song.name}]存在于[${this.aggregationPlaylist[index].name}]`)
+                // if(this.playlistId === this.aggregationPlaylist[this.selectedIndex].id){
+                //   AppStorage.setOrCreate('current_playlist_data', this.aggregationPlaylist[this.selectedIndex])
+                // }
+              }else{
+                ToastUtil.showShort(`[${song.name}]添加到[${this.aggregationPlaylist[index].name}]`)
+              }
+            },
+            onAction: (): void => {}
+          })
         }
       }
     ]

--- a/entry/src/main/ets/component/LyricItem.ets
+++ b/entry/src/main/ets/component/LyricItem.ets
@@ -42,12 +42,11 @@ export struct LyricItem {
         .fontWeight(FontWeight.Normal)
         .fontColor(this.getLyricStyle(this.index).fontColor)
         .opacity(this.getLyricStyle(this.index).opacity * 0.9)
-        .margin({ bottom: 4 })
+        .margin({ bottom: 2 })
         .padding({
           left: 16,
           right: 16,
-          top: 4,
-          bottom: 4
+          top: 4
         })
         .textAlign(TextAlign.Center)
         .borderRadius(8)
@@ -64,12 +63,11 @@ export struct LyricItem {
         .fontWeight(FontWeight.Normal)
         .fontColor(this.getLyricStyle(this.index).fontColor)
         .opacity(this.getLyricStyle(this.index).opacity * 0.9)
-        .margin({ bottom: 4 })
+        .margin({ bottom: 2 })
         .padding({
           left: 16,
           right: 16,
-          top: 4,
-          bottom: 4
+          top: 4
         })
         .textAlign(TextAlign.Center)
         .borderRadius(8)

--- a/entry/src/main/ets/component/LyricsView.ets
+++ b/entry/src/main/ets/component/LyricsView.ets
@@ -15,7 +15,6 @@ export struct LyricsView {
   @StorageProp('current_parsed_lyrics') private parsedLyrics: Array<LyricsLine> = []
   @StorageLink('current_lyrics_index') @Watch("onTimeUpdate") private currentLyricsIndex: number = 0
   @State mode_judge: boolean = false
-  @State private isAnimating: boolean = false
   @State private showTranslation: boolean = PreferencesCache.showTranslationLyric()
   @StorageProp('current_lyrics_has_translation') private hasTranslation: boolean = false // 是否有翻译歌词
   @StorageProp('current_lyrics_has_transliteration') private hasTransliteration: boolean = false
@@ -37,8 +36,7 @@ export struct LyricsView {
   // 监听当前播放时间更新
   onTimeUpdate() {
     // 如果索引变化且不在动画中，则更新并滚动
-    if (this.currentLyricsIndex !== -1 && !this.isAnimating && !this.isManualScroll) {
-      this.isAnimating = true
+    if (this.currentLyricsIndex !== -1 && !this.isManualScroll) {
       this.scrollToLyric(this.currentLyricsIndex)
     }
   }
@@ -55,7 +53,6 @@ export struct LyricsView {
       duration: this.SCROLL_ANIMATION_DURATION,
       curve: Curve.EaseOut,
       onFinish: () => {
-        this.isAnimating = false
         this.isAutoScroll = false
       }
     }, () => {
@@ -64,7 +61,7 @@ export struct LyricsView {
   }
 
   private getTargetIndex(index: number) {
-    return Math.max(0, this.mode_judge ? index - (10 * (this.showTranslation ? 0.1 : 0.3)) : index - (this.showTranslation ? 0 : 1))
+    return Math.max(0, this.mode_judge ? index - (this.showTranslation ? 1 : 3) : index - (this.showTranslation ? 0 : 1))
   }
 
   // 切换翻译显示状态
@@ -100,7 +97,8 @@ export struct LyricsView {
         } else {
           List({
             initialIndex: this.getTargetIndex(this.currentLyricsIndex),
-            scroller: this.scroller
+            scroller: this.scroller,
+            space: 12
           }) {
             ForEach(this.parsedLyrics, (item: LyricsLine, index) => {
               ListItem() {
@@ -136,9 +134,6 @@ export struct LyricsView {
           })
           .contentStartOffset(100)
           .contentEndOffset(100)
-          .fadingEdge(true, {
-            fadingEdgeLength: LengthMetrics.vp(80)
-          })
         }
       }
       .width(StyleConstants.FULL_WIDTH)
@@ -185,7 +180,6 @@ export struct LyricsView {
   // 歌词点击处理
   private handleLyricClick(time: number, index: number) {
     // 更新UI状态
-    this.isAnimating = true
     this.isManualScroll = false
     this.currentLyricsIndex = index
     AppStorage.setOrCreate('test_index', this.parsedLyrics[index].text)

--- a/entry/src/main/ets/component/LyricsView.ets
+++ b/entry/src/main/ets/component/LyricsView.ets
@@ -2,11 +2,11 @@ import { StyleConstants } from "../constants/StyleConstants";
 import { avPlayerManager } from "../util/AVPlayerManager";
 import { PreferencesCache } from "../util/PreferenceCache";
 import { App, LengthMetrics, LengthUnit } from '@kit.ArkUI'
-import { LyricsLine } from "../util/LyricsManager";
+import LyricsManager, { LyricsLine } from "../util/LyricsManager";
 import { VibrationControl } from "../util/DeviceController";
 import { EventHelper } from "../util/EventHelper";
 import { LyricItem } from "./LyricItem";
-import { LogUtil } from "@pura/harmony-utils";
+import { LogUtil, ToastUtil } from "@pura/harmony-utils";
 
 @Component
 export struct LyricsView {
@@ -24,6 +24,10 @@ export struct LyricsView {
   @State private manualScrollTimeoutId: number = -1; // 手动滚动超时ID
   @State private isManualScroll: boolean = false; // 是否处于手动滚动状态
   @State private isAutoScroll: boolean = false; // 是否处于自动滚动状态
+  @State private currentLyricsOffsetTime: number = PreferencesCache.currentLyricsOffsetTime()
+  @State private lastLyricsOffsetTime: number = PreferencesCache.currentLyricsOffsetTime()
+  @State private lastStep: number = 0
+  @State private isShow: boolean = false;
   uiContext: UIContext | undefined = undefined;
   aboutToAppear() {
     this.uiContext = this.getUIContext();
@@ -87,7 +91,7 @@ export struct LyricsView {
   }
 
   build() {
-    Stack({ alignContent: Alignment.TopEnd }) {
+    Stack({ alignContent: Alignment.Bottom }) {
       Column() {
         if (this.parsedLyrics.length === 0) {
           Text($r('app.string.no_lyric_available'))
@@ -154,27 +158,86 @@ export struct LyricsView {
         .translate({ x: -72, y: -72 })
         .onClick(() => this.toggleTranslation())
       }
+
+      Column() {
+        Text(`历史偏移：${this.lastLyricsOffsetTime}MS`)
+          .fontSize(16)
+          .fontColor(Color.White)
+          .fontWeight(StyleConstants.FONT_WEIGHT_FIVE)
+          .animation({
+            duration: 200
+          })
+        Text(`当前偏移：${this.currentLyricsOffsetTime}MS`)
+          .fontSize(16)
+          .fontColor(Color.White)
+          .fontWeight(StyleConstants.FONT_WEIGHT_FIVE)
+          .animation({
+            duration: 200
+          })
+      }
+      .alignItems(HorizontalAlign.Center)
+      .justifyContent(FlexAlign.Center)
+      .margin({ bottom: '30%' })
+      .backgroundBlurStyle(BlurStyle.BACKGROUND_THICK)
+      .height(60)
+      .width(200)
+      .borderRadius(15)
+      .visibility(this.isShow ? Visibility.Visible : Visibility.None)
+
     }
     .width(StyleConstants.FULL_WIDTH)
     .height(StyleConstants.FULL_HEIGHT)
     .gesture(
-      PinchGesture()
-        .onActionUpdate((event: PinchGestureEvent) => {
-          if (event.scale > 1.1) {
-            this.debounce(() => {
-              if(!this.showTranslation && (this.hasTranslation || this.hasTransliteration)){
+      GestureGroup(GestureMode.Exclusive,
+
+        PanGesture({ fingers: 3 , direction: PanDirection.Vertical, distance: 1 })
+          .onActionEnd((event: GestureEvent)=> {
+            const currentStep = Math.floor(event.offsetY / 20)
+            if(currentStep < 1){
+              LyricsManager.setPreTime(0)
+              PreferencesCache.currentLyricsOffsetTime(0)
+              this.currentLyricsOffsetTime = 0
+              this.lastLyricsOffsetTime = 0
+              VibrationControl.handlePresetVibration(1)
+              ToastUtil.showToast(`当前歌词偏移：${this.currentLyricsOffsetTime}MS`)
+            }
+            if(currentStep > 1){
+              if(this.hasTranslation || this.hasTransliteration){
                 this.toggleTranslation()
               }
-            });
-          } else if (event.scale < 0.9) {
-            this.debounce(() => {
-              if(this.showTranslation && (this.hasTranslation || this.hasTransliteration)){
-                this.toggleTranslation()
-              }
-            });
-          }
-        })
+            }
+          }),
+
+        PanGesture({ fingers: 2 , direction: PanDirection.Vertical, distance: 1 })
+          .onActionStart(() => {
+            this.isShow = true
+          })
+          .onActionUpdate((event: GestureEvent)=> {
+            const newStep = Math.floor(event.offsetY / 50)
+            if(this.handleUpdate(newStep)){
+              this.currentLyricsOffsetTime = this.lastLyricsOffsetTime + this.lastStep*100
+              LyricsManager.setPreTime(this.currentLyricsOffsetTime)
+              PreferencesCache.currentLyricsOffsetTime(this.currentLyricsOffsetTime)
+              VibrationControl.handlePresetVibration(1)
+            }
+          })
+          .onActionEnd(() => {
+            this.lastStep = 0
+            this.isShow = false
+            this.lastLyricsOffsetTime = this.currentLyricsOffsetTime
+            ToastUtil.showToast(`当前歌词偏移：${this.currentLyricsOffsetTime}MS`)
+          }),
+
+      )
     )
+  }
+
+  handleUpdate(newStep: number): boolean {
+    if (newStep !== this.lastStep) {
+      this.lastStep = newStep
+      return true // 需要触发震动
+    }
+    return false
   }
 
   // 歌词点击处理
@@ -194,7 +257,7 @@ export struct LyricsView {
 
   private startManualScrollTimer() {
     // 清除之前的计时器
-    if (this.manualScrollTimeoutId) {
+    if (this.manualScrollTimeoutId !== -1) {
       clearTimeout(this.manualScrollTimeoutId)
     }
 

--- a/entry/src/main/ets/component/PlaylistItem.ets
+++ b/entry/src/main/ets/component/PlaylistItem.ets
@@ -1,14 +1,20 @@
-import { ToastUtil } from "@pura/harmony-utils";
+import { CustomContentOptions, DialogAction, DialogHelper } from "@pura/harmony-dialog";
+import { LogUtil, ToastUtil } from "@pura/harmony-utils";
 import { SourceAdapter } from "../adapter";
 import { StyleConstants } from "../constants/StyleConstants";
-import { Playlist } from "../type/Adapter";
+import { Playlist, PlaylistType, Song } from "../type/Adapter";
 import { cover } from "../util/AdapterHelper";
 import { PlaylistManager } from "../util/PlaylistManager";
+import { PreferencesCache } from "../util/PreferenceCache";
 import { PushPathHelper } from "../util/PushPathHelper";
+import { AddAggregationPlaylist } from "./CustomTextBuilder";
+const TAG = 'PlaylistItem'
 
 @Reusable
 @Component
 export struct PlaylistItem {
+  @State playlistName: string | undefined = ''
+  @State playlistDesc: string | undefined = ''
   @Prop playlist: Playlist
   onPlaylistSelected?: (playlist: Playlist) => void;
 
@@ -16,7 +22,7 @@ export struct PlaylistItem {
     Row() {
       // 封面图 - 现代直角设计
       Stack({ alignContent: Alignment.BottomStart }) {
-        Image(cover(this.playlist?.cover || '', 120))
+        Image(cover(this.playlist?.cover || '', 120) ?? this.playlist?.cover)
           .width(58)
           .height(58)
           .objectFit(ImageFit.Cover)
@@ -34,7 +40,7 @@ export struct PlaylistItem {
           .textOverflow({ overflow: TextOverflow.Ellipsis })
 
         // 歌曲信息
-        if (this.playlist?.size) {
+        if (this.playlist?.size || this.playlist?.size === 0) {
           Text(`${this.playlist.size}首`)
             .fontSize(12)
             .fontColor($r('app.color.text_secondary'))
@@ -85,35 +91,132 @@ export struct PlaylistItem {
   }
 
   private generatePlaylistMenu(playlist: Playlist): Array<MenuElement> {
-    return [
-      {
-        value: $r('app.string.play_this_playlist'),
-        action: () => {
-          PushPathHelper.loading("Playing", async () => {
-            const playlistDetail = await SourceAdapter.getPlaylistDetail(playlist)
-            const songs = playlistDetail?.songs?.filter(song => song.privilege.playable)
-            if (!songs || songs.length === 0) {
-              ToastUtil.showShort("此歌单无可播放歌曲")
-              return
+    if(playlist?.type === PlaylistType.AGGREGATION){
+      return [
+        {
+          value: $r('app.string.play_this_playlist'),
+          action: () => {
+            PushPathHelper.loading("Playing", async () => {
+              const playlistDetail = await SourceAdapter.getAggregationPlaylistDetail(playlist)
+              const songs = playlistDetail?.songs?.filter(song => song.privilege.playable)
+              if (!songs || songs.length === 0) {
+                ToastUtil.showShort("此歌单无可播放歌曲")
+                return
+              }
+              PlaylistManager.loadPlaylist(songs, songs[0])
+            })
+          }
+        },
+        {
+          value: $r('app.string.add_to_play_next'),
+          action: () => {
+            PushPathHelper.loading("Playing", async () => {
+              const playlistDetail = await SourceAdapter.getAggregationPlaylistDetail(playlist)
+              const songs = playlistDetail?.songs?.filter(song => song.privilege.playable)
+              if (!songs || songs.length === 0) {
+                ToastUtil.showShort("此歌单无可播放歌曲")
+                return
+              }
+              PlaylistManager.insertSongs(songs)
+            })
+          }
+        },
+        {
+          value: $r('app.string.edit_playlist_info'),
+          action: () => {
+            let options: CustomContentOptions = {
+              title: $r('app.string.create_playlist'),
+              contentBuilder: (): void => {
+                this.CustomTextBuilder()
+              },
+              onAction: (action) => {
+                if(action === DialogAction.TWO){
+                  this.updateAggregationPlaylist(playlist)
+                }
+              }
             }
-            PlaylistManager.loadPlaylist(songs, songs[0])
-          })
+            this.playlistName = playlist.name
+            this.playlistDesc = playlist.description
+            DialogHelper.showCustomContentDialog(options)
+          }
+        },
+        {
+          value: $r('app.string.delete_playlist'),
+          action: () => {
+            DialogHelper.showAlertDialog({
+              primaryTitle: `是否删除歌单[${playlist.name}]？`,
+              primaryButton: $r('app.string.cancel'),
+              secondaryButton: $r('app.string.confirm'),
+              onAction: (action: number, dialogId: string): void => {
+                if(action === DialogAction.TWO){
+                  this.deleteFromAggregationPlaylist(playlist)
+                }
+              }
+            })
+          }
         }
-      },
-      {
-        value: $r('app.string.add_to_play_next'),
-        action: () => {
-          PushPathHelper.loading("Playing", async () => {
-            const playlistDetail = await SourceAdapter.getPlaylistDetail(playlist)
-            const songs = playlistDetail?.songs?.filter(song => song.privilege.playable)
-            if (!songs || songs.length === 0) {
-              ToastUtil.showShort("此歌单无可播放歌曲")
-              return
-            }
-            PlaylistManager.insertSongs(songs)
-          })
+      ]
+    }else{
+      return [
+        {
+          value: $r('app.string.play_this_playlist'),
+          action: () => {
+            PushPathHelper.loading("Playing", async () => {
+              const playlistDetail = await SourceAdapter.getPlaylistDetail(playlist)
+              const songs = playlistDetail?.songs?.filter(song => song.privilege.playable)
+              if (!songs || songs.length === 0) {
+                ToastUtil.showShort("此歌单无可播放歌曲")
+                return
+              }
+              PlaylistManager.loadPlaylist(songs, songs[0])
+            })
+          }
+        },
+        {
+          value: $r('app.string.add_to_play_next'),
+          action: () => {
+            PushPathHelper.loading("Playing", async () => {
+              const playlistDetail = await SourceAdapter.getPlaylistDetail(playlist)
+              const songs = playlistDetail?.songs?.filter(song => song.privilege.playable)
+              if (!songs || songs.length === 0) {
+                ToastUtil.showShort("此歌单无可播放歌曲")
+                return
+              }
+              PlaylistManager.insertSongs(songs)
+            })
+          }
         }
-      }
-    ]
+      ]
+    }
+  }
+
+  updateAggregationPlaylist(playlist: Playlist) {
+    try {
+      PreferencesCache.updatePlaylistsCache('aggregation_playlist', playlist, this.playlistName, this.playlistDesc)
+      this.playlistName = ''
+      this.playlistDesc = ''
+      LogUtil.info(`[${TAG}]`, `歌单[${this.playlistName}]更新成功`)
+    } catch(error) {
+      LogUtil.info(`[${TAG}]`, `歌单[${this.playlistName}]更新失败: ${JSON.stringify(error)}`)
+    }
+  }
+
+  deleteFromAggregationPlaylist(playlist: Playlist) {
+    try {
+      PreferencesCache.deletePlaylistCache('aggregation_playlist', playlist)
+      ToastUtil.showShort("成功删除歌单")
+      LogUtil.info(`[${TAG}]`, `歌单[${playlist.name}]删除成功`)
+    } catch(error) {
+      ToastUtil.showShort("删除歌单失败!")
+      LogUtil.info(`[${TAG}]`, `歌单[${playlist.name}]删除失败: ${JSON.stringify(error)}`)
+    }
+  }
+
+  @Builder
+  CustomTextBuilder() {
+    AddAggregationPlaylist({
+      playlistName: this.playlistName,
+      playlistDesc: this.playlistDesc
+    })
   }
 }

--- a/entry/src/main/ets/component/PlaylistView.ets
+++ b/entry/src/main/ets/component/PlaylistView.ets
@@ -11,6 +11,7 @@ import { LogUtil } from '@pura/harmony-utils';
 export struct PlaylistView {
   @StorageLink('current_playing_song') currentSong: Song | null = null;
   @StorageLink('current_playing_playlist') @Watch('onPlaylistChanged') playlist: Array<Song> = [];
+  @StorageLink("current_playlist_data") curPlaylist: Playlist | null = null
   @State isLoading: boolean = false;
   @State highlightIndex: number = -1;
   @State currentIndex: number = -1
@@ -186,12 +187,14 @@ export struct PlaylistView {
           LazyForEach(this.songDataSource, (song: Song, index: number) => {
             ListItem() {
               SongInfo({
+                playlistId: this.curPlaylist?.id,
                 song: song,
                 showIndex: false,
                 active: this.currentSong?.id === song.id,
                 highlight: this.highlightIndex === index,
                 disabled: song.privilege && !song.privilege.playable,
-                onTap: (song: Song) => this.handleSongTap(song)
+                onTap: (song: Song) => this.handleSongTap(song),
+                isShowMenu: false
               }) {
                 // 使用rightSlot插槽添加删除按钮
                 this.DeleteButton(song)

--- a/entry/src/main/ets/component/PlaylistView.ets
+++ b/entry/src/main/ets/component/PlaylistView.ets
@@ -13,6 +13,7 @@ export struct PlaylistView {
   @StorageLink('current_playing_playlist') @Watch('onPlaylistChanged') playlist: Array<Song> = [];
   @State isLoading: boolean = false;
   @State highlightIndex: number = -1;
+  @State currentIndex: number = -1
 
   // 数据源和预取器
   private songDataSource: SongDataSourcePrefetching = new SongDataSourcePrefetching(null);
@@ -114,27 +115,27 @@ export struct PlaylistView {
     }
 
     // 查找当前歌曲的索引
-    const currentIndex = this.playlist.findIndex(song =>
+    this.currentIndex = this.playlist.findIndex(song =>
     song.id === this.currentSong?.id
     );
 
 
-    if (currentIndex !== -1) {
+    if (this.currentIndex !== -1) {
       // 确保数据被预取
       if (this.prefetcher) {
-        this.songDataSource.prefetch(currentIndex);
+        this.songDataSource.prefetch(this.currentIndex);
       }
 
       // 设置高亮效果
-      this.highlightIndex = currentIndex;
+      this.highlightIndex = this.currentIndex;
       setTimeout(() => {
         this.highlightIndex = -1;
-      }, 1500);
+      }, 300)
 
       // 滚动到指定位置
-      setTimeout(() => {
-        this.scrollController.scrollToIndex(Math.max(0, currentIndex), true);
-      }, 100);
+      // setTimeout(() => {
+      //   this.scrollController.scrollToIndex(Math.max(0, this.currentIndex), true);
+      // }, 100);
     }
   }
 
@@ -180,7 +181,7 @@ export struct PlaylistView {
       if (!this.playlist || this.playlist.length === 0) {
         this.EmptyState()
       } else {
-        List({ scroller: this.scrollController }) {
+        List({ initialIndex: this.currentIndex, scroller: this.scrollController }) {
           // 使用LazyForEach实现懒加载歌曲列表
           LazyForEach(this.songDataSource, (song: Song, index: number) => {
             ListItem() {

--- a/entry/src/main/ets/component/Segment.ets
+++ b/entry/src/main/ets/component/Segment.ets
@@ -3,13 +3,12 @@ import { Artist, Playlist, Song } from "../type/Adapter"
 import { Cover } from "./Cover"
 import { HorizontalScroll } from "./HorizontalScroll"
 
-@Reusable
 @Component
 export struct Segment {
   @Prop loading: boolean = false
   @Prop lists: Object[]
   @Prop type: string
-  title: string | Resource = ''
+  @State title: string | Resource = ''
   actionText: string | undefined | Resource = undefined
   onActionClick?: () => void
   radius: string | number = 8

--- a/entry/src/main/ets/component/SongInfo.ets
+++ b/entry/src/main/ets/component/SongInfo.ets
@@ -1,21 +1,30 @@
+import { DialogAction, DialogHelper } from "@pura/harmony-dialog";
+import { LogUtil, ToastUtil } from "@pura/harmony-utils";
 import { StyleConstants } from "../constants/StyleConstants";
-import { Song } from "../type/Adapter";
+import { Playlist, PlaylistType, Song } from "../type/Adapter";
+import { PreferencesCache } from "../util/PreferenceCache";
+const TAG = 'SongInfo'
 
 @Reusable
 @Component
 export struct SongInfo {
+  @StorageLink('aggregation_playlist') aggregationPlaylist: Playlist[] = PreferencesCache.getPlaylistCache('aggregation_playlist')
+  @Prop playlistId: number | string
+  @Prop playlistType: PlaylistType
   @Prop song: Song
   showBorder: boolean = true;
   onTap?: (song: Song) => void;
   @Prop active: boolean = false;
   @Prop disabled: boolean = false;
   @Prop index: number = 0;
+  @Prop isShowMenu: boolean
   @Prop showIndex: boolean = true;
   @Watch('updateHighlightState') @Prop highlight: boolean = false; // 新增高亮参数
   @BuilderParam rightSlot?: () => void;
   @State On_Mouse:boolean =false
   // 用于高亮动画的状态变量
   @State private isHighlighting: boolean = false;
+  @State selectedIndex: number = 0
 
   // 监听highlight属性变化
   aboutToAppear() {
@@ -111,6 +120,24 @@ export struct SongInfo {
         .alignItems(HorizontalAlign.Start)
         .layoutWeight(1)
 
+        if(this.isShowMenu){
+          Button({ type: ButtonType.Circle }) {
+            Image($r('app.media.ic_more'))
+              .width(20)
+              .height(20)
+              .fillColor($r('app.color.icon_normal'))
+              .opacity(0.9)
+          }
+          .width(48)
+          .height(48)
+          .bindMenu(this.generateSongMenu(this.song))
+          .clickEffect({ level: ClickEffectLevel.LIGHT })
+          .stateStyles({
+            pressed: this.pressedMenuStyles,
+            normal: this.normalMenuStyles
+          })
+        }
+
         // 右侧插槽 - 简约处理
         if (this.rightSlot) {
           this.rightSlot()
@@ -152,6 +179,88 @@ export struct SongInfo {
     .padding({ left: 12, right: 12, top: 4, bottom: 4 })
   }
 
+  generateSongMenu(song: Song): Array<MenuElement> {
+    if(this.playlistType === PlaylistType.AGGREGATION) {
+      return [
+        {
+          value: $r('app.string.add_to_playlist'),
+          action: () => {
+            DialogHelper.showSelectDialog({
+              title: $r('app.string.add_to_playlist'),
+              confirm: $r('app.string.back'),
+              selectedIndex: 0,
+              radioContent: this.aggregationPlaylist.map(playlist => playlist.name),
+              onCheckedChanged: (index) => {
+                this.selectedIndex = index
+                if(PreferencesCache.addSongToAggregationPlaylist(this.aggregationPlaylist[this.selectedIndex], song)){
+                  ToastUtil.showShort(`已存在于[${this.aggregationPlaylist[index].name}]`)
+                }else{
+                  ToastUtil.showShort(`已添加到[${this.aggregationPlaylist[index].name}]`)
+                }
+                if(this.playlistId === this.aggregationPlaylist[this.selectedIndex].id){
+                  AppStorage.setOrCreate('current_playlist_data', this.aggregationPlaylist[this.selectedIndex])
+                }
+              },
+              onAction: (): void => {}
+            })
+          }
+        },
+        {
+          value: $r('app.string.delete_song'),
+          action: () => {
+            DialogHelper.showAlertDialog({
+              primaryTitle: `是否删除歌曲[${song.name}]？`,
+              primaryButton: $r('app.string.cancel'),
+              secondaryButton: $r('app.string.confirm'),
+              onAction: (action: number): void => {
+                if(action === DialogAction.TWO){
+                  this.deleteFromAggregationSongs(this.playlistId, song)
+                }
+              }
+            })
+          }
+        }
+      ]
+    } else {
+      return [
+        {
+          value: $r('app.string.add_to_playlist'),
+          action: () => {
+            DialogHelper.showSelectDialog({
+              title: $r('app.string.add_to_playlist'),
+              confirm: $r('app.string.back'),
+              selectedIndex: 0,
+              radioContent: this.aggregationPlaylist.map(playlist => playlist.name),
+              onCheckedChanged: (index) => {
+                this.selectedIndex = index
+                if(PreferencesCache.addSongToAggregationPlaylist(this.aggregationPlaylist[this.selectedIndex], song)){
+                  ToastUtil.showShort(`已存在于[${this.aggregationPlaylist[index].name}]`)
+                }else{
+                  ToastUtil.showShort(`已添加到[${this.aggregationPlaylist[index].name}]`)
+                }
+                if(this.playlistId === this.aggregationPlaylist[this.selectedIndex].id){
+                  AppStorage.setOrCreate('current_playlist_data', this.aggregationPlaylist[this.selectedIndex])
+                }
+              },
+              onAction: (): void => {}
+            })
+          }
+        }
+      ]
+    }
+  }
+
+  deleteFromAggregationSongs(playlistId: number | string, song: Song){
+    try {
+      PreferencesCache.deleteSongCache('aggregation_playlist', playlistId, song)
+      ToastUtil.showShort("成功删除歌曲")
+      LogUtil.info(`[${TAG}]`, `歌曲[${song.name}]删除成功`)
+    } catch(error) {
+      ToastUtil.showShort("删除歌曲失败!")
+      LogUtil.info(`[${TAG}]`, `歌曲[${song.name}]删除失败: ${JSON.stringify(error)}`)
+    }
+  }
+
   @Styles pressedStyles(): void {
     .borderWidth(1)
     .borderColor($r('app.color.text_click'))
@@ -159,5 +268,15 @@ export struct SongInfo {
 
   @Styles normalStyles(): void {
     .borderWidth(0)
+  }
+
+  @Styles pressedMenuStyles(): void {
+    .backgroundColor($r("app.color.homepage_menu_button_pressed"))
+    .animation({ duration: 300, curve: Curve.LinearOutSlowIn })
+  }
+
+  @Styles normalMenuStyles(): void {
+    .backgroundColor('transparent')
+    .animation({ duration: 300, curve: Curve.LinearOutSlowIn })
   }
 }

--- a/entry/src/main/ets/component/SongInfo.ets
+++ b/entry/src/main/ets/component/SongInfo.ets
@@ -25,10 +25,10 @@ export struct SongInfo {
   updateHighlightState() {
     if (this.highlight) {
       this.isHighlighting = true;
-      // 高亮持续1.5秒后自动消失
+      // 高亮持续0.3秒后自动消失
       setTimeout(() => {
         this.isHighlighting = false;
-      }, 1500);
+      }, 300);
     }
   }
 

--- a/entry/src/main/ets/component/SongInfo.ets
+++ b/entry/src/main/ets/component/SongInfo.ets
@@ -188,7 +188,7 @@ export struct SongInfo {
             DialogHelper.showSelectDialog({
               title: $r('app.string.add_to_playlist'),
               confirm: $r('app.string.back'),
-              selectedIndex: 0,
+              selectedIndex: -1,
               radioContent: this.aggregationPlaylist.map(playlist => playlist.name),
               onCheckedChanged: (index) => {
                 this.selectedIndex = index
@@ -229,7 +229,7 @@ export struct SongInfo {
             DialogHelper.showSelectDialog({
               title: $r('app.string.add_to_playlist'),
               confirm: $r('app.string.back'),
-              selectedIndex: 0,
+              selectedIndex: -1,
               radioContent: this.aggregationPlaylist.map(playlist => playlist.name),
               onCheckedChanged: (index) => {
                 this.selectedIndex = index

--- a/entry/src/main/ets/component/TitleHeader.ets
+++ b/entry/src/main/ets/component/TitleHeader.ets
@@ -128,6 +128,7 @@ export struct TitleHeader {
               .maxLines(1)
               .padding({ left: 16 })
           }
+          .visibility(this.backActive ? Visibility.Visible : Visibility.None)
           .width(StyleConstants.FULL_WIDTH)
           .onHover((isHover: boolean) => {
             if(isHover){

--- a/entry/src/main/ets/component/TitleHeader.ets
+++ b/entry/src/main/ets/component/TitleHeader.ets
@@ -62,27 +62,26 @@ export struct TitleHeader {
     Stack({ alignContent: Alignment.Start }) {
       Column(){
         // PC工具栏适配
-        if(this.topRect > 0){
-          Row(){}
+        Row()
           .height(this.topRect)
           .backgroundColor('transparent')
           .width('100%')
+          .visibility(this.topRect > 0 ? Visibility.Visible : Visibility.None)
+
+        Row(){
+          Image($r('app.media.icon'))
+            .height(this.decorHeight/2)
+            .width(this.decorHeight/2)
+            .margin({ left: 16 })
+          Blank().width(5)
+          Text('云享社').fontSize(14).fontWeight(FontWeight.Bold)
         }
-        if(this.decorHeight > 0){
-          Row(){
-            Image($r('app.media.icon'))
-              .height(this.decorHeight/2)
-              .width(this.decorHeight/2)
-              .margin({ left: 16 })
-            Blank().width(5)
-            Text('云享社').fontSize(14).fontWeight(FontWeight.Bold)
-          }
-          .justifyContent(FlexAlign.Start)
-          .alignItems(VerticalAlign.Center)
-          .height(this.decorHeight)
-          .backgroundColor('transparent')
-          .width('100%')
-        }
+        .justifyContent(FlexAlign.Start)
+        .alignItems(VerticalAlign.Center)
+        .height(this.decorHeight)
+        .backgroundColor('transparent')
+        .width('100%')
+        .visibility(this.decorHeight > 0 ? Visibility.Visible : Visibility.None)
 
         Row() {
           Row() {

--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -102,20 +102,14 @@ export default class EntryAbility extends UIAbility {
 
   async onWindowStageCreate(windowStage: window.WindowStage): Promise<void> {
     LogUtil.info(`[${TAG}]`, 'Ability onWindowStageCreate');
-    WindowUtil.loadContent(windowStage);
-    WindowUtil.setWindowProperties(windowStage)
-    WindowUtil.setWindowListeners(windowStage)
-    WindowUtil.setPipManager(windowStage)
-    WindowUtil.setWindowFullScreen(windowStage, true)
-    WindowUtil.setWindowStatus(windowStage)
+    WindowUtil.loadContent(windowStage, this.page);
 
-    if (this.page){
-      WindowUtil.setPageJump(this.page)
-    }
   }
 
   onWindowStageWillDestroy(windowStage: window.WindowStage){
-    WindowUtil.setWindowFullScreen(windowStage, false)
+    windowStage.getMainWindow().then((windowClass) => {
+      WindowUtil.setWindowFullScreen(windowClass, false)
+    })
   }
 
   onWindowStageDestroy(): void {

--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -107,6 +107,7 @@ export default class EntryAbility extends UIAbility {
     WindowUtil.setWindowListeners(windowStage)
     WindowUtil.setPipManager(windowStage)
     WindowUtil.setWindowFullScreen(windowStage, true)
+    WindowUtil.setWindowStatus(windowStage)
 
     if (this.page){
       WindowUtil.setPageJump(this.page)

--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -106,11 +106,15 @@ export default class EntryAbility extends UIAbility {
     WindowUtil.setWindowProperties(windowStage)
     WindowUtil.setWindowListeners(windowStage)
     WindowUtil.setPipManager(windowStage)
+    WindowUtil.setWindowFullScreen(windowStage, true)
 
     if (this.page){
       WindowUtil.setPageJump(this.page)
     }
+  }
 
+  onWindowStageWillDestroy(windowStage: window.WindowStage){
+    WindowUtil.setWindowFullScreen(windowStage, false)
   }
 
   onWindowStageDestroy(): void {

--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -17,6 +17,7 @@ import { DialogHelper } from '@pura/harmony-dialog';
 import { PipManager } from '../util/PipManager';
 import { PreferencesCache } from '../util/PreferenceCache';
 import ResourceManager from '../util/ResourceManager';
+import { SourceAdapter } from '../adapter';
 
 const TAG = 'EntryAbility'
 export default class EntryAbility extends UIAbility {
@@ -91,6 +92,8 @@ export default class EntryAbility extends UIAbility {
     this.callee.on(CallMethod.REQUEST_UPDATE_CARD, FormUtils.requestUpdatePlayCard);
     this.callee.on(CallMethod.PLAY_BY_ACTION, FormUtils.playByActionCall);
     this.callee.on(CallMethod.COLLECT_ACTION, FormUtils.collectActionCall);
+
+    SourceAdapter.getAllRecommend()
   }
 
   onDestroy(): void {

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -325,7 +325,7 @@ struct Index_page {
       onActionClick: async () => {
         this.recommendSongs = await SourceAdapter.getRecommendSongs(this.limit)
       },
-    }).key('Index-R')
+    })
   }
 
   @Builder
@@ -339,7 +339,7 @@ struct Index_page {
       onActionClick: async () => {
         this.recommendPlaylist = await SourceAdapter.getRecommendList(this.limit)
       },
-    }).key('Index-R')
+    })
   }
 
   @Builder
@@ -354,7 +354,7 @@ struct Index_page {
       onActionClick: async () => {
         this.recommendArtists = await SourceAdapter.getRecommendArtists(this.limit)
       },
-    }).key('Index-R')
+    })
   }
 
   @Builder
@@ -364,7 +364,7 @@ struct Index_page {
       type: 'TopPlaylist',
       title: $r('app.string.chart'),
       loading: this.loading
-    }).key('Index-R')
+    })
   }
 
   @Builder

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -164,15 +164,15 @@ struct Index_page {
     // 立即初始化数据
     this.initData()
     let productSeries:string=deviceInfo.productSeries
-    let devicetype:string =deviceInfo.deviceType
-    if (devicetype!='phone'&&productSeries!='VDE'){
+    let deviceType: string =deviceInfo.deviceType
+    if (deviceType!='phone'&&productSeries!='VDE'){
       AppStorage.setOrCreate<boolean>('isWideScreen', true)
     }else {
       AppStorage.setOrCreate<boolean>('isWideScreen', false)
 
     }
-    AppStorage.setOrCreate("devicetype", devicetype)
-    PreferencesCache.setUserPreference('devicetype', devicetype)
+    AppStorage.setOrCreate("devicetype", deviceType)
+    PreferencesCache.setUserPreference('devicetype', deviceType)
     if(productSeries=='VDE') {
       PreferencesCache.setUserPreference('is_Pura_X', '1')
     }else {
@@ -221,27 +221,26 @@ struct Index_page {
 
     Column(){
       // PC工具栏适配
-      if(this.topRect > 0){
-        Row(){}
+      Row()
         .height(this.topRect)
         .backgroundColor('transparent')
         .width('100%')
+        .visibility(this.topRect > 0 ? Visibility.Visible : Visibility.None)
+
+      Row(){
+        Image($r('app.media.icon'))
+          .height(this.decorHeight/2)
+          .width(this.decorHeight/2)
+          .margin({ left: 16 })
+        Blank().width(5)
+        Text('云享社').fontSize(14).fontWeight(FontWeight.Bold)
       }
-      if(this.decorHeight > 0){
-        Row(){
-          Image($r('app.media.icon'))
-            .height(this.decorHeight/2)
-            .width(this.decorHeight/2)
-            .margin({ left: 16 })
-          Blank().width(5)
-          Text('云享社').fontSize(14).fontWeight(FontWeight.Bold)
-        }
-        .justifyContent(FlexAlign.Start)
-        .alignItems(VerticalAlign.Center)
-        .height(this.decorHeight)
-        .backgroundColor('transparent')
-        .width('100%')
-      }
+      .justifyContent(FlexAlign.Start)
+      .alignItems(VerticalAlign.Center)
+      .height(this.decorHeight)
+      .backgroundColor('transparent')
+      .width('100%')
+      .visibility(this.decorHeight > 0 ? Visibility.Visible : Visibility.None)
 
       Row() {
         Text($r("app.string.homepage"))

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -85,7 +85,7 @@ struct Index_page {
   @StorageProp('bottomRect') bottomRect: number = 0
   @StorageProp('topRect') topRect: number = 0
   @StorageProp('winHeight') winHeight: number = 0
-  @State HorizontalMode_ctrl: string = PreferencesCache.getUserPreference('HorizontalMode_ctrl', '0')
+  @State HorizontalMode_ctrl: string = PreferencesCache.getUserPreference('HorizontalMode_ctrl', '1')
   @State scrollController: ScrollController = new ScrollController({
     onIndexChange: (index) => {
       this.onMenuIconClick(index)

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -21,6 +21,9 @@ import { deviceInfo } from '@kit.BasicServicesKit'
 import { PipManager } from '../util/PipManager';
 import { avPlayerManager } from '../util/AVPlayerManager';
 import { IS_2IN1_UI }from '../For_2in1_UI/FOR2IN1'
+import { Aggregation } from '../view/Aggregation'
+import { LogUtil } from '@pura/harmony-utils'
+
 // 缓存常用值以避免重复计算
 const COLUMNS_TEMPLATE_LG = '1fr 1fr 1fr 1fr'
 const COLUMNS_TEMPLATE_SM = '1fr 1fr'
@@ -45,6 +48,8 @@ struct Index {
       Index_page()
     } else if (name === 'Download') {
       Download()
+    } else if (name === 'Aggregation') {
+      Aggregation()
     }
   }
 
@@ -78,11 +83,11 @@ struct Index_page {
   private scroller: Scroller = new Scroller()
   @StorageLink("user_data_source") adapters: SourceConfig[] = PreferencesCache.getUserDataSource()
   // 使用StorageLink保持数据同步
-  @StorageLink("index_recommend_playlist") recommendPlaylist: Playlist[] = []
-  @StorageLink("index_recommend_songs") recommendSongs: Song[] = []
-  @StorageLink("index_recommend_artists") recommendArtists: Artist[] = []
-  @StorageLink("index_recommend_toplist") topList: Playlist[] = []
-  @State loading: boolean = true
+  @StorageLink("index_recommend_playlist") recommendPlaylist: Playlist[] = PreferencesCache.getPlaylistCache('index_recommend_playlist')
+  @StorageLink("index_recommend_songs") recommendSongs: Song[] = PreferencesCache.getSongCache('index_recommend_songs')
+  @StorageLink("index_recommend_artists") recommendArtists: Artist[] = PreferencesCache.getArtistCache('index_recommend_artists')
+  @StorageLink("index_recommend_toplist") topList: Playlist[] = PreferencesCache.getPlaylistCache('index_recommend_toplist')
+  @State loading: boolean = false
   // 避让导航栏高度
   @StorageProp('bottomRect') bottomRect: number = 0
   @StorageProp('topRect') topRect: number = 0
@@ -161,8 +166,6 @@ struct Index_page {
     this.breakpointSystem.register(this.getUIContext())
     HorizontalMode(this.getUIContext().getHostContext() as Context, this.HorizontalMode_ctrl === '1')
     AppStorage.setOrCreate("pageStack", this.pageStack)
-    // 立即初始化数据
-    this.initData()
     let productSeries:string=deviceInfo.productSeries
     let deviceType: string =deviceInfo.deviceType
     if (deviceType!='phone'&&productSeries!='VDE'){
@@ -182,21 +185,12 @@ struct Index_page {
 
   async initData() {
     this.loading = true
-
-    try {
-      // 并行加载数据并捕获异常
-      await Promise.all([
-        SourceAdapter.getRecommendList(this.limit),
-        SourceAdapter.getRecommendSongs(this.limit),
-        SourceAdapter.getRecommendArtists(this.limit),
-        SourceAdapter.getTopList(this.limit),
-        SourceAdapter.getUserPlaylist()
-      ])
-    } catch (error) {
-      console.error('Failed to load data', error)
-    } finally {
+    SourceAdapter.getAllRecommend().then(() => {
+      LogUtil.info(`[${TAG}]`, `首页刷新数据成功`)
+    }).finally(() => {
       this.loading = false
-    }
+    })
+
   }
 
   onPageShow(): void {
@@ -418,39 +412,42 @@ struct Index_page {
                   this.MenuGrid()
                 }
 
-                if (this.loading || (this.recommendPlaylist.length > 0 || this.recommendSongs.length > 0
-                  || this.recommendArtists.length > 0 || this.topList.length > 0)) {
-                  if(this.recommendPlaylist.length > 0){
-                    this.RecommendedSongs()
-                  }
-
-                  if(this.recommendSongs.length > 0){
-                    this.RecommendedPlaylists()
-                  }
-
-                  if(this.recommendArtists.length > 0){
-                    this.RecommendedArtists()
-                  }
-
-                  if(this.topList.length > 0){
-                    this.TopLists()
-                  }
-                } else if(!this.loading) {
-                  ListItem() {
-                    Row() {
-                      Column() {
-                        Text($r('app.string.no_recommendations'))
-                          .fontWeight(StyleConstants.FONT_WEIGHT_SEVEN)
-                          .fontColor($r('app.color.text_hint'))
-                          .fontSize(16)
-                      }
-                      .width(StyleConstants.FULL_WIDTH)
-                      .height(StyleConstants.FULL_HEIGHT)
-                      .justifyContent(FlexAlign.Center)
-                    }
-                    .height(this.getBlankHeight())
-                  }
+                ListItem(){
+                  this.RecommendedSongs()
                 }
+                .visibility(this.loading || this.recommendPlaylist.length > 0 ? Visibility.Visible : Visibility.None)
+
+                ListItem(){
+                  this.RecommendedPlaylists()
+                }
+                .visibility(this.loading || this.recommendSongs.length > 0 ? Visibility.Visible : Visibility.None)
+
+                ListItem(){
+                  this.RecommendedArtists()
+                }
+                .visibility(this.loading || this.recommendArtists.length > 0 ? Visibility.Visible : Visibility.None)
+
+                ListItem(){
+                  this.TopLists()
+                }
+                .visibility(this.loading || this.topList.length > 0 ? Visibility.Visible : Visibility.None)
+
+                ListItem() {
+                  Row() {
+                    Column() {
+                      Text($r('app.string.no_recommendations'))
+                        .fontWeight(StyleConstants.FONT_WEIGHT_SEVEN)
+                        .fontColor($r('app.color.text_hint'))
+                        .fontSize(16)
+                    }
+                    .width(StyleConstants.FULL_WIDTH)
+                    .height(StyleConstants.FULL_HEIGHT)
+                    .justifyContent(FlexAlign.Center)
+                  }
+                  .height(this.getBlankHeight())
+                }
+                .visibility(this.hasRecommendation() ? Visibility.Visible : Visibility.None)
+
               } else {
                 ListItem() {
                   this.EmptyDataSource()
@@ -498,6 +495,14 @@ struct Index_page {
       }
       return false
     })
+  }
+
+  hasRecommendation(): boolean {
+    return !this.loading
+      && this.recommendPlaylist.length === 0
+      && this.recommendSongs.length === 0
+      && this.recommendArtists.length === 0
+      && this.topList.length === 0
   }
 
   getBlankHeight(): number {

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -20,7 +20,7 @@ import { HeaderAnimation } from '../component/HeaderAnimation'
 import { deviceInfo } from '@kit.BasicServicesKit'
 import { PipManager } from '../util/PipManager';
 import { avPlayerManager } from '../util/AVPlayerManager';
-import {FOR_2IN1_UI, IS_2IN1_UI}from '../For_2in1_UI/FOR2IN1'
+import { IS_2IN1_UI }from '../For_2in1_UI/FOR2IN1'
 // 缓存常用值以避免重复计算
 const COLUMNS_TEMPLATE_LG = '1fr 1fr 1fr 1fr'
 const COLUMNS_TEMPLATE_SM = '1fr 1fr'
@@ -69,6 +69,8 @@ struct Index_page {
   @State version: string = '2.2.0.y'
   @State blankHeight: number = 0
   @State limit: number = 10
+  @State page_judge: string = 'index'
+  @State title: string = '首页'
   @Consume('NavPathStack') pageStack: NavPathStack
   @StorageProp('currentBreakpoint') currentBreakpoint: string = 'sm'
   private breakpointSystem = new BreakpointSystem()
@@ -398,7 +400,10 @@ struct Index_page {
   build() {
     NavDestination() {
       if (this.zhishi_UI === '1'){
-        IS_2IN1_UI()
+        IS_2IN1_UI({
+          page_judge: this.page_judge,
+          title: this.title
+        })
       }else {
         Stack({ alignContent: Alignment.Bottom }) {
           Column(){
@@ -486,6 +491,14 @@ struct Index_page {
     .hideBackButton(true)
     .backgroundColor($r('app.color.page_background'))
     .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM, LayoutSafeAreaEdge.TOP])
+    .onBackPressed(() => {
+      if(this.page_judge !== 'index'){
+        this.page_judge = 'index'
+        this.title = '首页'
+        return true
+      }
+      return false
+    })
   }
 
   getBlankHeight(): number {

--- a/entry/src/main/ets/type/Adapter.ets
+++ b/entry/src/main/ets/type/Adapter.ets
@@ -66,7 +66,9 @@ export enum PlaylistType {
   // 歌手
   ARTIST = 'artist',
   // 播控/电台
-  DJ = 'dj'
+  DJ = 'dj',
+  // 聚合
+  AGGREGATION = 'aggregation'
 }
 
 export interface PlayListMeta {
@@ -79,7 +81,7 @@ export interface Playlist {
   // 歌单名称
   name?: string;
   // 歌单封面
-  cover?: string;
+  cover?: string | Resource;
   // 歌曲数量
   size?: number;
   // 创建者

--- a/entry/src/main/ets/util/AVPlayerManager.ets
+++ b/entry/src/main/ets/util/AVPlayerManager.ets
@@ -285,21 +285,21 @@ class AVPlayerManager {
     });
 
     this.avSession.on('playNext', () => {
-      ClickUtil.debounce(async () => {
+      ClickUtil.throttle(async () => {
         const nextSong = PlaylistManager.playNext()
         if (nextSong) {
           PlaylistManager.playSong(nextSong)
         }
-      }, 500, "playNext")
+      }, 500)
     })
 
     this.avSession.on('playPrevious', () => {
-      ClickUtil.debounce(async () => {
+      ClickUtil.throttle(async () => {
         const prevSong = PlaylistManager.playPrevious()
         if (prevSong) {
           PlaylistManager.playSong(prevSong)
         }
-      }, 500, "playPrevious")
+      }, 500)
     })
 
     this.avSession.on('setLoopMode', () => {

--- a/entry/src/main/ets/util/AdapterHelper.ets
+++ b/entry/src/main/ets/util/AdapterHelper.ets
@@ -1,5 +1,9 @@
-export function cover(url?: string, size = 100) {
-  return `${url}?param=${size}y${size}`
+export function cover(url?: string | Resource, size = 100): string | Resource{
+  if(typeof url === 'string') {
+    return `${url}?param=${size}y${size}`
+  } else {
+    return url as Resource
+  }
 }
 
 export function sample<T>(arr: Array<T>) {

--- a/entry/src/main/ets/util/EventHelper.ets
+++ b/entry/src/main/ets/util/EventHelper.ets
@@ -114,7 +114,7 @@ const playSong = async (song: Song, path: string, cached: boolean, pause: boolea
       assetId: `track-${song.id}-${song.source?.id}`,
       duration: song.duration,
       title: song.name,
-      mediaImage: cover(song.album.cover, 512),
+      mediaImage: cover(song.album.cover, 512) as string,
       artist: song.artists.map(a => a.name).join("/"),
       lyric: song.meta?.lyric?.normal,
     })

--- a/entry/src/main/ets/util/LyricsManager.ets
+++ b/entry/src/main/ets/util/LyricsManager.ets
@@ -1,7 +1,9 @@
+import { LogUtil } from "@pura/harmony-utils";
 import { Song } from "../type/Adapter";
 import { avPlayerManager } from "./AVPlayerManager";
 import { EventHelper } from "./EventHelper";
 import FormUtils from "./FormUtils";
+import { PreferencesCache } from "./PreferenceCache";
 
 export class LyricsLine {
   time: number; // 时间点（毫秒）
@@ -19,6 +21,7 @@ export class LyricsLine {
   }
 }
 
+const TAG = 'LyricsManager'
 class LyricsManager {
   private song: Song | undefined
   private originalLyrics: string = ''
@@ -31,12 +34,14 @@ class LyricsManager {
   private lyricsTimer: number = -1
   private lastIndex: number = -1
   private currentIndex: number = 0
-  private readonly PRE_HIGHLIGHT_TIME: number = 500 // 提前切换时间
+  private BASE_PRE_TIME: number = 500 // 基础提前时间
+  private PRE_HIGHLIGHT_TIME: number = 0 // 提前切换时间
   private isInit: boolean = false
   private currentSongName: string = ''
 
   async init(){
 
+    this.PRE_HIGHLIGHT_TIME = PreferencesCache.currentLyricsOffsetTime() + this.BASE_PRE_TIME
     this.song = AppStorage.get<Song>('current_playing_song')
     this.originalLyrics = this.song?.meta?.lyric?.normal ?? ''
     this.translatedLyrics = this.song?.meta?.lyric?.translation ?? ''
@@ -54,6 +59,11 @@ class LyricsManager {
     }
     this.parseLyrics()
     this.isInit = true
+  }
+
+  setPreTime(preTime: number){
+    this.PRE_HIGHLIGHT_TIME = this.BASE_PRE_TIME + preTime
+    LogUtil.info(`${TAG}`, ` currentLyricsOffsetTime: ${preTime}`)
   }
 
   async start(){

--- a/entry/src/main/ets/util/LyricsManager.ets
+++ b/entry/src/main/ets/util/LyricsManager.ets
@@ -150,7 +150,7 @@ class LyricsManager {
    */
   private parseLyricsText(lrcText: string): LyricsLine[] {
     const lines = lrcText.split('\n')
-    const timeRegex = /\[(\d{2}):(\d{2})[\.:](\d{2,3})\]/
+    const timeRegex = /\[(\d{2}):(\d{2})(?:[\.:](\d{2,3}))?\]/
     const tempLyrics: LyricsLine[] = []
 
     lines.forEach(line => {
@@ -158,7 +158,7 @@ class LyricsManager {
       if (match) {
         const minutes = parseInt(match[1])
         const seconds = parseInt(match[2])
-        const ms = parseInt(match[3])
+        const ms = match[3] ? parseInt(match[3]) : 0
         // 统一转换为毫秒
         const time = minutes * 60 * 1000 + seconds * 1000 + (ms < 100 ? ms * 10 : ms)
         const text = line.replace(timeRegex, '').trim()

--- a/entry/src/main/ets/util/PreferenceCache.ets
+++ b/entry/src/main/ets/util/PreferenceCache.ets
@@ -1,5 +1,5 @@
 import { Artist, ID, Playlist, Song, SourceConfig } from "../type/Adapter";
-import { PreferencesUtil } from '@pura/harmony-utils';
+import { LogUtil, PreferencesUtil } from '@pura/harmony-utils';
 
 // 比特率类型
 export type BitrateType = 128000 | 192000 | 320000 | 350000 | 999000 | number;
@@ -30,6 +30,7 @@ export function getQualityLevel(bitrate: BitrateType): QualityLevel {
 /**
  * 系统设置偏好
  */
+const TAG = 'PreferencesCache'
 export class PreferencesCache {
   private static CACHE_MAP = new Map<string, string>();
 
@@ -351,5 +352,18 @@ export class PreferencesCache {
   static setSongCache(strIndex: string, sourceConfig: Song[]): void {
     PreferencesCache.setCache(strIndex, JSON.stringify(sourceConfig));
     AppStorage.setOrCreate(strIndex, sourceConfig);
+  }
+
+  /**
+   * 显示翻译/音译歌词
+   * @param value 是否显示
+   * @returns 是否显示
+   */
+  static currentLyricsOffsetTime(value?: number): number {
+    if (value !== undefined) {
+      PreferencesCache.setUserPreference('current_lyrics_offset_time', value > 0 ? `+${value}` : `-${value}`);
+      LogUtil.info(`[${TAG}]`, ` currentLyricsOffsetTime: ${value}`)
+    }
+    return parseInt(PreferencesCache.getUserPreference('current_lyrics_offset_time', '0'))
   }
 }

--- a/entry/src/main/ets/util/PreferenceCache.ets
+++ b/entry/src/main/ets/util/PreferenceCache.ets
@@ -361,7 +361,7 @@ export class PreferencesCache {
    */
   static currentLyricsOffsetTime(value?: number): number {
     if (value !== undefined) {
-      PreferencesCache.setUserPreference('current_lyrics_offset_time', value > 0 ? `+${value}` : `-${value}`);
+      PreferencesCache.setUserPreference('current_lyrics_offset_time', `${value}`);
       LogUtil.info(`[${TAG}]`, ` currentLyricsOffsetTime: ${value}`)
     }
     return parseInt(PreferencesCache.getUserPreference('current_lyrics_offset_time', '0'))

--- a/entry/src/main/ets/util/PreferenceCache.ets
+++ b/entry/src/main/ets/util/PreferenceCache.ets
@@ -1,5 +1,5 @@
 import { Artist, ID, Playlist, Song, SourceConfig } from "../type/Adapter";
-import { LogUtil, PreferencesUtil } from '@pura/harmony-utils';
+import { LogUtil, PreferencesUtil, ToastUtil } from '@pura/harmony-utils';
 
 // 比特率类型
 export type BitrateType = 128000 | 192000 | 320000 | 350000 | 999000 | number;
@@ -352,6 +352,106 @@ export class PreferencesCache {
   static setSongCache(strIndex: string, sourceConfig: Song[]): void {
     PreferencesCache.setCache(strIndex, JSON.stringify(sourceConfig));
     AppStorage.setOrCreate(strIndex, sourceConfig);
+  }
+
+  static addPlaylistsCache(strIndex: string, sourceConfig: Playlist[]): void {
+    let playlists: Playlist[] = JSON.parse(PreferencesCache.getCache(strIndex, '[]'));
+    playlists.push(...sourceConfig)
+    PreferencesCache.setCache(strIndex, JSON.stringify(playlists));
+    AppStorage.setOrCreate(strIndex, playlists);
+  }
+
+  static updatePlaylistsCache(strIndex: string, sourceConfig: Playlist, name: string | undefined, desc: string | undefined): void {
+    let playlists: Playlist[] = JSON.parse(PreferencesCache.getCache(strIndex, '[]'));
+    playlists.filter((item: Playlist) => {
+      if (item.id === sourceConfig.id) {
+        item.name = name
+        item.description = desc
+      }
+    })
+    PreferencesCache.setCache(strIndex, JSON.stringify(playlists));
+    AppStorage.setOrCreate(strIndex, playlists);
+  }
+
+  static deletePlaylistCache(strIndex: string, sourceConfig: Playlist): void {
+    let playlists: Playlist[] = JSON.parse(PreferencesCache.getCache(strIndex, '[]'));
+    playlists.filter((item: Playlist, index: number) => {
+      if (item.id === sourceConfig.id) {
+        playlists.splice(index, 1)
+        LogUtil.info(`[${TAG}]`, `删除后的歌单：${JSON.stringify(playlists)}`)
+        PreferencesCache.setCache(strIndex, JSON.stringify(playlists));
+        AppStorage.setOrCreate(strIndex, playlists);
+      }
+    })
+  }
+
+  static deleteSongCache(strIndex: string, playlistId: number | string, song: Song): void {
+    // 1. 从缓存中获取播放列表数组
+    let playlists: Playlist[] = JSON.parse(PreferencesCache.getCache(strIndex, '[]'));
+
+    // 2. 查找目标播放列表（根据sourceConfig.id）
+    let targetPlaylistIndex: number = -1
+    targetPlaylistIndex = playlists.findIndex(
+      (playlist: Playlist) => playlist.id === playlistId
+    );
+
+    // 3. 如果找到目标播放列表
+    if (targetPlaylistIndex !== -1) {
+      // 4. 从songs数组中移除指定歌曲（根据song.id）
+      playlists[targetPlaylistIndex].songs = playlists[targetPlaylistIndex].songs?.filter(
+        (s: Song) => s.id !== song.id
+      );
+      playlists[targetPlaylistIndex].size = playlists[targetPlaylistIndex].songs?.length
+
+      // 5. 更新缓存
+      PreferencesCache.setCache(strIndex, JSON.stringify(playlists));
+      AppStorage.setOrCreate(strIndex, playlists);
+      AppStorage.setOrCreate('current_playlist_data', playlists[targetPlaylistIndex])
+
+      // 6. 日志记录（可选）
+      LogUtil.info(`[${TAG}]`, `已从播放列表${playlists[targetPlaylistIndex].name}中删除歌曲: ${song.name}`);
+    } else {
+      LogUtil.warn(`[${TAG}]`, `未找到ID为${playlists[targetPlaylistIndex].name}的播放列表`);
+    }
+
+  }
+
+  static addSongToAggregationPlaylist(playlist: Playlist, song: Song): boolean{
+    let playlists: Playlist[] = JSON.parse(PreferencesCache.getCache('aggregation_playlist', '[]'));
+    let resultIndex: number = -1
+    let isExist: boolean = false
+    playlists.filter((item: Playlist, index: number) => {
+      if (item.id === playlist.id) {
+        resultIndex = index
+        if(item.songs){
+          item.songs.filter((s: Song) => {
+            if(!isExist && s.id === song.id){
+              isExist = true
+            }
+          })
+        }
+      }
+    })
+    if(isExist){
+      LogUtil.info(`[${TAG}]`, `[${song.name}]已存在于歌单[${playlists[resultIndex].name}]`)
+    }else{
+      let item: Playlist = playlists[resultIndex]
+      if(item.songs){
+        playlists[resultIndex].songs?.push(song)
+      }else{
+        playlists[resultIndex].songs = [song]
+      }
+      playlists[resultIndex].size = playlists[resultIndex].songs?.length
+      LogUtil.info(`[${TAG}]`, `添加后的歌单：${JSON.stringify(playlists)}`)
+      PreferencesCache.setCache('aggregation_playlist', JSON.stringify(playlists));
+      AppStorage.setOrCreate('aggregation_playlist', playlists);
+    }
+    return isExist
+  }
+
+  static clearPlaylistsCache(strIndex: string): void {
+    PreferencesCache.setCache(strIndex, '[]');
+    AppStorage.setOrCreate(strIndex, JSON.parse('[]'));
   }
 
   /**

--- a/entry/src/main/ets/util/RealTimeTrendDetector.ets
+++ b/entry/src/main/ets/util/RealTimeTrendDetector.ets
@@ -1,0 +1,114 @@
+import { LogUtil } from "@pura/harmony-utils";
+import { PlaylistManager } from "./PlaylistManager";
+
+type Trend = '+' | '-';
+const TAG = 'RealTimeTrendDetector';
+
+class StrictTrendDetector {
+  private readonly windowSize: number;
+  private readonly minTrendDiff: number;
+  private dataWindow: number[];
+  private trendSequence: Trend[]; // 当前正在构建的趋势序列
+  private coolDownCounter: number;
+  private readonly coolDownPeriod: number = 20;
+
+  constructor(windowSize: number = 6, minTrendDiff: number = 4) { // 提高默认阈值
+    this.windowSize = windowSize;
+    this.minTrendDiff = minTrendDiff;
+    this.dataWindow = [];
+    this.trendSequence = [];
+    this.coolDownCounter = 0;
+  }
+
+  update(newValue: number): void {
+    // if (this.coolDownCounter > 0) {
+    //   this.coolDownCounter--;
+    //   return;
+    // }
+
+    // 更新数据窗口
+    this.dataWindow.push(newValue);
+    if (this.dataWindow.length > this.windowSize) {
+      this.dataWindow.shift();
+    }
+
+    // 至少需要2个点才能开始检测
+    if (this.dataWindow.length >= 2) {
+      this.detectTrendStrictly();
+    }
+  }
+
+  private detectTrendStrictly(): void {
+    // 当前需要检测的趋势方向（交替变化）
+    const expectedTrend: Trend | null = this.trendSequence.length % 2 === 1 ? '+' : '-';
+
+    // 尝试在接下来的3个点内找到符合预期的趋势
+    const maxLookAhead = Math.min(3, this.dataWindow.length - 1);
+    let trendFound: Trend | null = null;
+
+    // 优先检查长区间（3点），再检查短区间（2点）
+    for (let points = 3; points >= 2; points--) {
+      if (this.dataWindow.length < points) continue;
+
+      const startIdx = this.dataWindow.length - points;
+      const diff = this.dataWindow[this.dataWindow.length - 1] - this.dataWindow[startIdx];
+
+      if (Math.abs(diff) >= this.minTrendDiff) {
+        const currentTrend = diff > 0 ? '+' : '-';
+
+        // 必须符合交替趋势要求
+        if (expectedTrend === null || currentTrend === expectedTrend) {
+          trendFound = currentTrend;
+          break;
+        }
+      }
+    }
+
+    // 结果处理
+    if (trendFound) {
+      this.trendSequence.push(trendFound);
+      LogUtil.info(TAG, `趋势序列更新: [${this.trendSequence.join('→')}], 数组: ${this.dataWindow.join('→')}`);
+
+      // 完整模式检测
+      if (this.trendSequence.length === 3 && this.checkFullPattern()) {
+        this.triggerAction();
+      }
+    } else {
+      // 未找到符合要求的趋势，重置检测
+      if (this.trendSequence.length > 0) {
+        LogUtil.info(TAG, `趋势中断，期待 ${expectedTrend} 但未找到，重置检测`);
+        this.trendSequence = []
+        this.dataWindow = []
+      }
+    }
+  }
+
+  private checkFullPattern(): boolean {
+    const target: Trend[] = ['-', '+', '-'];
+    return this.trendSequence.every((val, idx) => val === target[idx]);
+  }
+
+  private triggerAction(): void {
+    this.playNext();
+    LogUtil.info(TAG, `检测到完整波动模式: [${this.trendSequence.join('→')}], 数组: ${this.dataWindow.join('→')}`);
+    this.resetDetection();
+  }
+
+  private resetDetection(): void {
+    this.dataWindow = [];
+    this.trendSequence = [];
+    // this.coolDownCounter = this.coolDownPeriod;
+  }
+
+  private playNext(): void {
+    const nextSong = PlaylistManager.playNext();
+    if (nextSong) {
+      PlaylistManager.playSong(nextSong);
+      LogUtil.info(TAG, `切歌成功: ${nextSong.name}`);
+    } else {
+      LogUtil.info(TAG, '播放列表已到末尾');
+    }
+  }
+}
+
+export default new StrictTrendDetector();

--- a/entry/src/main/ets/util/RealTimeTrendDetector.ets
+++ b/entry/src/main/ets/util/RealTimeTrendDetector.ets
@@ -9,23 +9,15 @@ class StrictTrendDetector {
   private readonly minTrendDiff: number;
   private dataWindow: number[];
   private trendSequence: Trend[]; // 当前正在构建的趋势序列
-  private coolDownCounter: number;
-  private readonly coolDownPeriod: number = 20;
 
-  constructor(windowSize: number = 6, minTrendDiff: number = 4) { // 提高默认阈值
+  constructor(windowSize: number = 20, minTrendDiff: number = 3) {
     this.windowSize = windowSize;
     this.minTrendDiff = minTrendDiff;
     this.dataWindow = [];
     this.trendSequence = [];
-    this.coolDownCounter = 0;
   }
 
   update(newValue: number): void {
-    // if (this.coolDownCounter > 0) {
-    //   this.coolDownCounter--;
-    //   return;
-    // }
-
     // 更新数据窗口
     this.dataWindow.push(newValue);
     if (this.dataWindow.length > this.windowSize) {

--- a/entry/src/main/ets/util/ResourceManager.ets
+++ b/entry/src/main/ets/util/ResourceManager.ets
@@ -1,12 +1,16 @@
 import { BusinessError } from "@kit.BasicServicesKit";
 import { common } from "@kit.AbilityKit";
+import { resourceManager } from "@kit.LocalizationKit";
+import { LogUtil } from "@pura/harmony-utils";
 
+const TAG = 'ResourceManager'
 class ResourceManager {
 
   private static context: Context
 
   init(context: common.UIAbilityContext){
     ResourceManager.context = context
+    this.setDeviceConfiguration()
   }
 
   getStringArrayValueSync(res: Resource): string[] {
@@ -16,7 +20,7 @@ class ResourceManager {
     } catch (error) {
       let code = (error as BusinessError).code;
       let message = (error as BusinessError).message;
-      console.error(`getStringArrayValueSync failed, error code: ${code}, message: ${message}.`);
+      LogUtil.error(`[${TAG}]`, `getStringArrayValueSync failed, error code: ${code}, message: ${message}.`);
     } finally {
       return result
     }
@@ -29,9 +33,23 @@ class ResourceManager {
     } catch (error) {
       let code = (error as BusinessError).code;
       let message = (error as BusinessError).message;
-      console.error(`getStringArrayValueSync failed, error code: ${code}, message: ${message}.`);
+      LogUtil.error(`[${TAG}]`, `getStringArrayValueSync failed, error code: ${code}, message: ${message}.`);
     } finally {
       return result
+    }
+  }
+
+  setDeviceConfiguration(){
+    try {
+      ResourceManager.context.resourceManager.getConfiguration().then((value: resourceManager.Configuration) => {
+        AppStorage.setOrCreate<resourceManager.Configuration>('deviceConfiguration', value);
+        AppStorage.setOrCreate<resourceManager.DeviceType>('deviceType', value.deviceType);
+        LogUtil.info(`[${TAG}]`, `setDeviceConfiguration successfully: ${JSON.stringify(value)}}`)
+      }).catch((error: BusinessError) => {
+        LogUtil.info(`[${TAG}]`, `getConfiguration failed, error code: ${error.code}, message: ${error.message}.`)
+      });
+    } catch (error) {
+      LogUtil.error(`[${TAG}]`, `getConfiguration failed, error code: ${(error as BusinessError).code}, message: ${(error as BusinessError).message}.`)
     }
   }
 

--- a/entry/src/main/ets/util/SensorUtil.ets
+++ b/entry/src/main/ets/util/SensorUtil.ets
@@ -1,0 +1,37 @@
+import { sensor } from "@kit.SensorServiceKit";
+import { BusinessError } from "@kit.BasicServicesKit";
+import { LogUtil } from "@pura/harmony-utils";
+import RealTimeTrendDetector from "./RealTimeTrendDetector";
+
+const TAG = 'SensorUtil'
+class SensorUtil {
+
+  onAccelerometer(){
+    try {
+      sensor.on(sensor.SensorId.ACCELEROMETER, (data: sensor.AccelerometerResponse) => {
+        // LogUtil.info(`[${TAG}]`, `Succeeded in invoking on. X: ${data.x}, Y:  ${data.y}, Z:  ${data.z}. (x^2+y^2+z^2): ${Math.pow(data.x, 2)+Math.pow(data.y, 2)+Math.pow(data.z, 2)}`)
+        RealTimeTrendDetector.update(data.z)
+        // if(data.z < 0){
+        //   LogUtil.info(`[${TAG}]`, `这里有一个z的负值：${data.z}`);
+        // }
+        // LogUtil.info(`${Date.now()} ${data.z} `);
+      }, { interval: 100000000 });
+      LogUtil.info(`[${TAG}]`, 'Succeeded in invoking on');
+    } catch (error) {
+      let e: BusinessError = error as BusinessError;
+      LogUtil.error(`[${TAG}]`, `Failed to invoke on. Code: ${e.code}, message: ${e.message}`);
+    }
+  }
+
+  offAccelerometer(){
+    try {
+      sensor.off(sensor.SensorId.ACCELEROMETER);
+      LogUtil.info(`[${TAG}]`, 'Succeeded in invoking off');
+    } catch (error) {
+      let e: BusinessError = error as BusinessError;
+      console.error(`[${TAG}]`, `Failed to invoke off. Code: ${e.code}, message: ${e.message}`);
+    }
+  }
+}
+
+export default new SensorUtil()

--- a/entry/src/main/ets/util/WindowUtil.ets
+++ b/entry/src/main/ets/util/WindowUtil.ets
@@ -101,10 +101,11 @@ class WindowUtil {
         let isVisible = false;
         // 调用setWindowDecorVisible接口
         try {
+          const uiContext = windowClass.getUIContext()
           if(canIUse('SystemCapability.Window.SessionManager')){
             windowClass?.setWindowDecorVisible(isVisible);
             let height = windowClass?.getWindowDecorHeight();
-            AppStorage.setOrCreate('decorHeight', height);
+            AppStorage.setOrCreate('decorHeight', uiContext.px2vp(height));
           }
         } catch (exception) {
           LogUtil.error(`[${TAG}]`, `Failed to set the visibility of window decor. Cause code: ${exception.code}, message: ${exception.message}`);
@@ -169,6 +170,19 @@ class WindowUtil {
         LogUtil.error(`[${TAG}]`, `Failed to set the window to be full screen. Cause code: ${err.code}, message: ${err.message}`);
       });
     })
+  }
+
+  setWindowStatus(windowStage: window.WindowStage){
+    if(canIUse('SystemCapability.Window.SessionManager')) {
+      windowStage.getMainWindow().then((windowClass) => {
+        let windowStatus: window.WindowStatusType = windowClass.getWindowStatus()
+        AppStorage.setOrCreate<window.WindowStatusType>('windowStatus', windowStatus)
+
+        windowClass.on('windowStatusChange', (windowStatus: window.WindowStatusType) => {
+          AppStorage.setOrCreate('windowStatus', windowStatus)
+        })
+      })
+    }
   }
 
 }

--- a/entry/src/main/ets/util/WindowUtil.ets
+++ b/entry/src/main/ets/util/WindowUtil.ets
@@ -27,8 +27,8 @@ class WindowUtil {
         AppStorage.setOrCreate('winHeight', uiContext.px2vp(windowSize.height));
         AppStorage.setOrCreate('winWidthWithPx', windowSize.width);
         AppStorage.setOrCreate('winHeightWithPx', windowSize.height);
-        LogUtil.info(`[${TAG}]`, 'Succeeded in adding windowSizeChange listener.');
       });
+      LogUtil.info(`[${TAG}]`, 'Succeeded in adding windowSizeChange listener.');
 
       // 监听避让高度变化
       windowClass.on('avoidAreaChange', (avoidArea) => {
@@ -42,8 +42,8 @@ class WindowUtil {
           AppStorage.setOrCreate('rightCutoutRectHeight', uiContext.px2vp(avoidArea.area.rightRect.height))
           AppStorage.setOrCreate('rightCutoutRectWidth', uiContext.px2vp(avoidArea.area.rightRect.width))
         }
-        LogUtil.info(`[${TAG}]`, 'Succeeded in adding avoidAreaChange listener.');
       });
+      LogUtil.info(`[${TAG}]`, 'Succeeded in adding avoidAreaChange listener.');
     })
   }
 
@@ -138,6 +138,37 @@ class WindowUtil {
         LogUtil.error(`[${TAG}]`, `Failed to set the system bar to be invisible. Cause code: ${exception.code}, message: ${exception.message}`);
       }
     });
+  }
+
+  setWindowScreenOn(windowStage: window.WindowStage, isKeepScreenOn: boolean){
+    windowStage.getMainWindow().then((windowClass) => {
+      try {
+        windowClass.setWindowKeepScreenOn(isKeepScreenOn, (err: BusinessError) => {
+          const errCode: number = err.code;
+          if (errCode) {
+            LogUtil.error(`[${TAG}]`, `Failed to set the screen to be always on. Cause code: ${err.code}, message: ${err.message}`);
+            return;
+          }
+          LogUtil.info(`[${TAG}]`, `Succeeded in setting the screen to be always on: ${isKeepScreenOn}.`);
+        });
+      } catch (exception) {
+        LogUtil.error(`[${TAG}]`, `Failed to set the screen to be always on. Cause code: ${exception.code}, message: ${exception.message}`);
+      }
+    })
+  }
+
+  setWindowFullScreen(windowStage: window.WindowStage, isKeepScreenFull: boolean){
+    windowStage.getMainWindow().then((windowClass) => {
+      windowClass.setWindowLayoutFullScreen(isKeepScreenFull).then(() => {
+        if(isKeepScreenFull){
+          LogUtil.info(`[${TAG}]`, `Succeeded in setting the window to be full screen: ${isKeepScreenFull}.`);
+        }else{
+          LogUtil.info(`[${TAG}]`, `Succeeded in setting the window to be full screen: ${isKeepScreenFull}.`);
+        }
+      }).catch((err: BusinessError) => {
+        LogUtil.error(`[${TAG}]`, `Failed to set the window to be full screen. Cause code: ${err.code}, message: ${err.message}`);
+      });
+    })
   }
 
 }

--- a/entry/src/main/ets/util/WindowUtil.ets
+++ b/entry/src/main/ets/util/WindowUtil.ets
@@ -7,66 +7,66 @@ import { LogUtil } from '@pura/harmony-utils';
 const TAG = 'WindowUtil'
 class WindowUtil {
 
-  setPipManager(windowStage: window.WindowStage) {
-    if (!windowStage) return;
-    windowStage.getMainWindow().then((window) => {
-      let ctx = window.getUIContext();
-      // 通过主窗口UIContext创建typeNode节点
-      PipManager.getInstance().makeTypeNode(ctx);
-      LogUtil.info(`[${TAG}]`, 'Succeeded in create typeNode.');
-    })
+  setPipManager(windowClass: window.Window) {
+    const uiContext = windowClass.getUIContext();
+    // 通过主窗口UIContext创建typeNode节点
+    PipManager.getInstance().makeTypeNode(uiContext);
+    LogUtil.info(`[${TAG}]`, 'Succeeded in create typeNode.');
   }
 
-  setWindowListeners(windowStage: window.WindowStage) {
-    if (!windowStage) return;
-    windowStage.getMainWindow().then((windowClass) => {
-      const uiContext = windowClass.getUIContext()
-      // 监听窗口尺寸变化
-      windowClass.on('windowSizeChange', (windowSize) => {
-        AppStorage.setOrCreate('winWidth', uiContext.px2vp(windowSize.width));
-        AppStorage.setOrCreate('winHeight', uiContext.px2vp(windowSize.height));
-        AppStorage.setOrCreate('winWidthWithPx', windowSize.width);
-        AppStorage.setOrCreate('winHeightWithPx', windowSize.height);
-      });
-      LogUtil.info(`[${TAG}]`, 'Succeeded in adding windowSizeChange listener.');
+  setWindowListeners(windowClass: window.Window) {
+    const uiContext = windowClass.getUIContext()
+    // 监听窗口尺寸变化
+    windowClass.on('windowSizeChange', (windowSize) => {
+      AppStorage.setOrCreate('winWidth', uiContext.px2vp(windowSize.width));
+      AppStorage.setOrCreate('winHeight', uiContext.px2vp(windowSize.height));
+      AppStorage.setOrCreate('winWidthWithPx', windowSize.width);
+      AppStorage.setOrCreate('winHeightWithPx', windowSize.height);
+      if(canIUse('SystemCapability.Window.SessionManager')){
+        let height = windowClass.getWindowDecorHeight();
+        AppStorage.setOrCreate('decorHeight', uiContext.px2vp(height));
+      }
+    });
+    LogUtil.info(`[${TAG}]`, 'Succeeded in adding windowSizeChange listener.');
 
-      // 监听避让高度变化
-      windowClass.on('avoidAreaChange', (avoidArea) => {
-        if (avoidArea.type === window.AvoidAreaType.TYPE_SYSTEM) {
-          AppStorage.setOrCreate('topRect', uiContext.px2vp(avoidArea.area.topRect.height));
-        } else if (avoidArea.type === window.AvoidAreaType.TYPE_NAVIGATION_INDICATOR) {
-          AppStorage.setOrCreate('bottomRect', uiContext.px2vp(avoidArea.area.bottomRect.height));
-        } else if (avoidArea.type === window.AvoidAreaType.TYPE_CUTOUT) {
-          AppStorage.setOrCreate('leftCutoutRectHeight', uiContext.px2vp(avoidArea.area.leftRect.height))
-          AppStorage.setOrCreate('leftCutoutRectWidth', uiContext.px2vp(avoidArea.area.leftRect.width))
-          AppStorage.setOrCreate('rightCutoutRectHeight', uiContext.px2vp(avoidArea.area.rightRect.height))
-          AppStorage.setOrCreate('rightCutoutRectWidth', uiContext.px2vp(avoidArea.area.rightRect.width))
-        }
-      });
-      LogUtil.info(`[${TAG}]`, 'Succeeded in adding avoidAreaChange listener.');
-    })
+    // 监听避让高度变化
+    windowClass.on('avoidAreaChange', (avoidArea) => {
+      if (avoidArea.type === window.AvoidAreaType.TYPE_SYSTEM) {
+        AppStorage.setOrCreate('topRect', uiContext.px2vp(avoidArea.area.topRect.height));
+      } else if (avoidArea.type === window.AvoidAreaType.TYPE_NAVIGATION_INDICATOR) {
+        AppStorage.setOrCreate('bottomRect', uiContext.px2vp(avoidArea.area.bottomRect.height));
+      } else if (avoidArea.type === window.AvoidAreaType.TYPE_CUTOUT) {
+        AppStorage.setOrCreate('leftCutoutRectHeight', uiContext.px2vp(avoidArea.area.leftRect.height))
+        AppStorage.setOrCreate('leftCutoutRectWidth', uiContext.px2vp(avoidArea.area.leftRect.width))
+        AppStorage.setOrCreate('rightCutoutRectHeight', uiContext.px2vp(avoidArea.area.rightRect.height))
+        AppStorage.setOrCreate('rightCutoutRectWidth', uiContext.px2vp(avoidArea.area.rightRect.width))
+      }
+    });
+    LogUtil.info(`[${TAG}]`, 'Succeeded in adding avoidAreaChange listener.');
   }
 
-  setWindowProperties(windowStage: window.WindowStage) {
-    if (!windowStage) return;
-    windowStage.getMainWindow().then((windowClass) => {
-      const uiContext = windowClass.getUIContext()
-      // 获取窗口尺寸，存入AppStorage
-      AppStorage.setOrCreate('winWidth', uiContext.px2vp(windowClass.getWindowProperties().windowRect.width));
-      AppStorage.setOrCreate('winHeight', uiContext.px2vp(windowClass.getWindowProperties().windowRect.height));
-      AppStorage.setOrCreate('winWidthWithPx', windowClass.getWindowProperties().windowRect.width);
-      AppStorage.setOrCreate('winHeightWithPx', windowClass.getWindowProperties().windowRect.height);
-      // 获取避让高度，存入AppStorage
-      AppStorage.setOrCreate('topRect', uiContext.px2vp(windowClass.getWindowAvoidArea(window.AvoidAreaType.TYPE_SYSTEM).topRect.height));
-      AppStorage.setOrCreate('bottomRect', uiContext.px2vp(windowClass.getWindowAvoidArea(window.AvoidAreaType.TYPE_NAVIGATION_INDICATOR).bottomRect.height));
-      // 刘海屏避让区
-      AppStorage.setOrCreate('leftCutoutRectHeight', uiContext.px2vp(windowClass.getWindowAvoidArea(window.AvoidAreaType.TYPE_CUTOUT).leftRect.height))
-      AppStorage.setOrCreate('leftCutoutRectWidth', uiContext.px2vp(windowClass.getWindowAvoidArea(window.AvoidAreaType.TYPE_CUTOUT).leftRect.width))
-      AppStorage.setOrCreate('rightCutoutRectHeight', uiContext.px2vp(windowClass.getWindowAvoidArea(window.AvoidAreaType.TYPE_CUTOUT).rightRect.height))
-      AppStorage.setOrCreate('rightCutoutRectWidth', uiContext.px2vp(windowClass.getWindowAvoidArea(window.AvoidAreaType.TYPE_CUTOUT).rightRect.width))
-      LogUtil.info(`[${TAG}]`, 'Succeeded in initting window properties.');
-    })
+  setWindowProperties(windowClass: window.Window) {
+    const uiContext = windowClass.getUIContext()
+    // 获取窗口尺寸，存入AppStorage
+    AppStorage.setOrCreate('winWidth', uiContext.px2vp(windowClass.getWindowProperties().windowRect.width));
+    AppStorage.setOrCreate('winHeight', uiContext.px2vp(windowClass.getWindowProperties().windowRect.height));
+    AppStorage.setOrCreate('winWidthWithPx', windowClass.getWindowProperties().windowRect.width);
+    AppStorage.setOrCreate('winHeightWithPx', windowClass.getWindowProperties().windowRect.height);
+    // 获取避让高度，存入AppStorage
+    AppStorage.setOrCreate('topRect', uiContext.px2vp(windowClass.getWindowAvoidArea(window.AvoidAreaType.TYPE_SYSTEM).topRect.height));
+    AppStorage.setOrCreate('bottomRect', uiContext.px2vp(windowClass.getWindowAvoidArea(window.AvoidAreaType.TYPE_NAVIGATION_INDICATOR).bottomRect.height));
+    // 刘海屏避让区
+    AppStorage.setOrCreate('leftCutoutRectHeight', uiContext.px2vp(windowClass.getWindowAvoidArea(window.AvoidAreaType.TYPE_CUTOUT).leftRect.height))
+    AppStorage.setOrCreate('leftCutoutRectWidth', uiContext.px2vp(windowClass.getWindowAvoidArea(window.AvoidAreaType.TYPE_CUTOUT).leftRect.width))
+    AppStorage.setOrCreate('rightCutoutRectHeight', uiContext.px2vp(windowClass.getWindowAvoidArea(window.AvoidAreaType.TYPE_CUTOUT).rightRect.height))
+    AppStorage.setOrCreate('rightCutoutRectWidth', uiContext.px2vp(windowClass.getWindowAvoidArea(window.AvoidAreaType.TYPE_CUTOUT).rightRect.width))
+    if(canIUse('SystemCapability.Window.SessionManager')){
+      windowClass.setWindowDecorVisible(false);
+      let height = windowClass.getWindowDecorHeight();
+      AppStorage.setOrCreate('decorHeight', uiContext.px2vp(height));
+    }
 
+    LogUtil.info(`[${TAG}]`, 'Succeeded in initting window properties.');
   }
 
   setPageJump(page: string) {
@@ -78,7 +78,7 @@ class WindowUtil {
     }
   }
 
-  loadContent(windowStage: window.WindowStage) {
+  loadContent(windowStage: window.WindowStage, page: string | undefined | null) {
     if(!windowStage) return
 
     windowStage.loadContent('pages/Index', (err) => {
@@ -98,14 +98,15 @@ class WindowUtil {
           return;
         }
         LogUtil.info(`[${TAG}]`, 'Succeeded in loading the content.');
-        let isVisible = false;
         // 调用setWindowDecorVisible接口
         try {
-          const uiContext = windowClass.getUIContext()
-          if(canIUse('SystemCapability.Window.SessionManager')){
-            windowClass?.setWindowDecorVisible(isVisible);
-            let height = windowClass?.getWindowDecorHeight();
-            AppStorage.setOrCreate('decorHeight', uiContext.px2vp(height));
+          this.setWindowProperties(windowClass)
+          this.setWindowListeners(windowClass)
+          this.setPipManager(windowClass)
+          this.setWindowFullScreen(windowClass, true)
+          this.setWindowStatus(windowClass)
+          if (page){
+            this.setPageJump(page)
           }
         } catch (exception) {
           LogUtil.error(`[${TAG}]`, `Failed to set the visibility of window decor. Cause code: ${exception.code}, message: ${exception.message}`);
@@ -158,29 +159,26 @@ class WindowUtil {
     })
   }
 
-  setWindowFullScreen(windowStage: window.WindowStage, isKeepScreenFull: boolean){
-    windowStage.getMainWindow().then((windowClass) => {
-      windowClass.setWindowLayoutFullScreen(isKeepScreenFull).then(() => {
-        if(isKeepScreenFull){
-          LogUtil.info(`[${TAG}]`, `Succeeded in setting the window to be full screen: ${isKeepScreenFull}.`);
-        }else{
-          LogUtil.info(`[${TAG}]`, `Succeeded in setting the window to be full screen: ${isKeepScreenFull}.`);
-        }
-      }).catch((err: BusinessError) => {
-        LogUtil.error(`[${TAG}]`, `Failed to set the window to be full screen. Cause code: ${err.code}, message: ${err.message}`);
-      });
-    })
+  setWindowFullScreen(windowClass: window.Window, isKeepScreenFull: boolean){
+    windowClass.setWindowLayoutFullScreen(isKeepScreenFull).then(() => {
+      if(isKeepScreenFull){
+        LogUtil.info(`[${TAG}]`, `Succeeded in setting the window to be full screen: ${isKeepScreenFull}.`);
+      }else{
+        LogUtil.info(`[${TAG}]`, `Succeeded in setting the window to be full screen: ${isKeepScreenFull}.`);
+      }
+    }).catch((err: BusinessError) => {
+      LogUtil.error(`[${TAG}]`, `Failed to set the window to be full screen. Cause code: ${err.code}, message: ${err.message}`);
+    });
   }
 
-  setWindowStatus(windowStage: window.WindowStage){
+  setWindowStatus(windowClass: window.Window){
     if(canIUse('SystemCapability.Window.SessionManager')) {
-      windowStage.getMainWindow().then((windowClass) => {
-        let windowStatus: window.WindowStatusType = windowClass.getWindowStatus()
-        AppStorage.setOrCreate<window.WindowStatusType>('windowStatus', windowStatus)
+      let windowStatus: window.WindowStatusType = windowClass.getWindowStatus()
+      AppStorage.setOrCreate<window.WindowStatusType>('windowStatus', windowStatus)
 
-        windowClass.on('windowStatusChange', (windowStatus: window.WindowStatusType) => {
-          AppStorage.setOrCreate('windowStatus', windowStatus)
-        })
+      windowClass.on('windowStatusChange', (windowStatus: window.WindowStatusType) => {
+        AppStorage.setOrCreate('windowStatus', windowStatus)
+        LogUtil.info(`[${TAG}]`, `WindowStatus Change: ${windowStatus}.`);
       })
     }
   }

--- a/entry/src/main/ets/view/Aggregation.ets
+++ b/entry/src/main/ets/view/Aggregation.ets
@@ -1,16 +1,14 @@
 import { LazyData } from "@pie/lazy-data";
 import { CustomContentOptions, DialogAction, DialogHelper } from "@pura/harmony-dialog";
-import { SourceAdapter } from "../adapter";
 import { HeaderAnimation } from "../component/HeaderAnimation";
 import { MiniPlaybackControl } from "../component/MiniPlaybackControl";
 import { PlaylistItem } from "../component/PlaylistItem";
 import { TitleHeader } from "../component/TitleHeader";
 import { StyleConstants } from "../constants/StyleConstants";
-import { Playlist, PlaylistType, Song } from "../type/Adapter";
+import { Playlist, PlaylistType } from "../type/Adapter";
 import { PreferencesCache } from "../util/PreferenceCache";
 import { PushPathHelper } from "../util/PushPathHelper";
 import { ScrollController } from "../util/ScrollController";
-import { BusinessError } from "@kit.BasicServicesKit";
 import { LogUtil } from "@pura/harmony-utils";
 import { AddAggregationPlaylist } from "../component/CustomTextBuilder";
 
@@ -28,8 +26,8 @@ export struct Aggregation {
 
   @State groupHeight: number = 0
   @State aggregationData: LazyData<Playlist> = new LazyData<Playlist>(this.aggregationPlaylist)
-  @State playlistName: string | undefined = ''
-  @State playlistDesc: string | undefined = ''
+  @State playlistName: string | undefined = undefined
+  @State playlistDesc: string | undefined = undefined
   @State playlistCover: Resource | string = $r('app.media.icon_startwindow')
   @State scrollController: ScrollController = new ScrollController({
     onIndexChange: (index): void => this.onMenuIconClick(index),
@@ -192,20 +190,18 @@ export struct Aggregation {
   createAggregationPlaylist(){
     try {
       const timestamp: number = new Date().getTime();
-      const playlistName = this.playlistName ?? ''
-      const playListDesc = this.playlistDesc ?? ''
-      const playlistCover = this.playlistCover
       const playlist: Playlist = {
         id: `aggregation_playlist-${timestamp}`,
-        name: playlistName,
-        description: playListDesc,
-        cover: playlistCover,
+        name: this.playlistName ?? '默认歌单',
+        description: this.playlistDesc ?? '',
+        cover: this.playlistCover,
         size: 0,
         type: PlaylistType.AGGREGATION
       }
       PreferencesCache.addPlaylistsCache('aggregation_playlist', [playlist])
-      this.playlistName = ''
-      this.playlistDesc = ''
+      this.playlistName = undefined
+      this.playlistDesc = undefined
+      this.playlistCover = $r('app.media.icon_startwindow')
       LogUtil.info(`[${TAG}]`, `歌单[${this.playlistName}]添加成功`)
     } catch(error) {
       LogUtil.info(`[${TAG}]`, `歌单[${this.playlistName}]添加失败: ${JSON.stringify(error)}`)

--- a/entry/src/main/ets/view/Aggregation.ets
+++ b/entry/src/main/ets/view/Aggregation.ets
@@ -177,8 +177,6 @@ export struct Aggregation {
         onAction: (action) => {
           if(action === DialogAction.TWO){
             this.createAggregationPlaylist()
-          }else{
-            PreferencesCache.clearPlaylistsCache('aggregation_playlist')
           }
         }
       }

--- a/entry/src/main/ets/view/Aggregation.ets
+++ b/entry/src/main/ets/view/Aggregation.ets
@@ -1,0 +1,216 @@
+import { LazyData } from "@pie/lazy-data";
+import { CustomContentOptions, DialogAction, DialogHelper } from "@pura/harmony-dialog";
+import { SourceAdapter } from "../adapter";
+import { HeaderAnimation } from "../component/HeaderAnimation";
+import { MiniPlaybackControl } from "../component/MiniPlaybackControl";
+import { PlaylistItem } from "../component/PlaylistItem";
+import { TitleHeader } from "../component/TitleHeader";
+import { StyleConstants } from "../constants/StyleConstants";
+import { Playlist, PlaylistType, Song } from "../type/Adapter";
+import { PreferencesCache } from "../util/PreferenceCache";
+import { PushPathHelper } from "../util/PushPathHelper";
+import { ScrollController } from "../util/ScrollController";
+import { BusinessError } from "@kit.BasicServicesKit";
+import { LogUtil } from "@pura/harmony-utils";
+import { AddAggregationPlaylist } from "../component/CustomTextBuilder";
+
+const TAG = 'Aggregation'
+
+@Component
+export struct Aggregation {
+
+  @Consume('NavPathStack') pageStack: NavPathStack
+  @StorageLink('aggregation_playlist') aggregationPlaylist: Playlist[] = PreferencesCache.getPlaylistCache('aggregation_playlist')
+  @StorageProp('bottomRect') bottomRect: number = 0
+  @StorageProp('topRect') topRect: number = 0
+  @StorageProp('winHeight') winHeight: number = 0
+  private scroller: Scroller = new Scroller()
+
+  @State groupHeight: number = 0
+  @State aggregationData: LazyData<Playlist> = new LazyData<Playlist>(this.aggregationPlaylist)
+  @State playlistName: string | undefined = ''
+  @State playlistDesc: string | undefined = ''
+  @State playlistCover: Resource | string = $r('app.media.icon_startwindow')
+  @State scrollController: ScrollController = new ScrollController({
+    onIndexChange: (index): void => this.onMenuIconClick(index),
+    componentTag: TAG
+  }).linkController(this.scroller)
+
+  build() {
+    NavDestination() {
+      Stack({ alignContent: Alignment.BottomEnd }) {
+        Column(){
+          this.Title()
+
+          this.AggregatePlayList()
+        }
+        .width(StyleConstants.FULL_WIDTH)
+        .height(StyleConstants.FULL_HEIGHT)
+
+        MiniPlaybackControl()
+
+        this.AddButton()
+      }
+      .width(StyleConstants.FULL_WIDTH)
+      .height(StyleConstants.FULL_HEIGHT)
+    }
+    .hideToolBar(true)
+    .hideTitleBar(true)
+    .backgroundColor($r('app.color.page_background'))
+    .mode(NavDestinationMode.STANDARD)
+    .width(StyleConstants.FULL_WIDTH)
+    .height(StyleConstants.FULL_HEIGHT)
+  }
+
+  @Builder
+  Title() {
+    TitleHeader({
+      title: $r('app.string.aggregation'),
+      backActive: this.scrollController.currentIndex === 0
+    })
+  }
+
+  @Builder
+  AggregatePlayList() {
+    List({ scroller: this.scroller }){
+      ListItem() {
+        HeaderAnimation({ scrollController: this.scrollController, isShowLoadingProgress: true })
+      }
+
+      if(this.aggregationPlaylist.length === 0){
+        ListItem() {
+          Column() {
+            Text($r('app.string.no_aggregation_playlist'))
+              .fontWeight(StyleConstants.FONT_WEIGHT_SEVEN)
+              .fontSize(16)
+              .fontColor($r('app.color.text_secondary'))
+          }
+          .width(StyleConstants.FULL_WIDTH)
+          .height(StyleConstants.FULL_HEIGHT)
+          .justifyContent(FlexAlign.Center)
+          .alignItems(HorizontalAlign.Center)
+        }
+      } else {
+        ListItemGroup(){
+          ForEach(this.aggregationPlaylist, (playlist: Playlist, index: number) => {
+            ListItem(){
+              PlaylistItem({
+                playlist: playlist,
+                onPlaylistSelected: (item: Playlist) => {
+                  PushPathHelper.pushPath(this.pageStack, "Playlist", async () => {
+                    AppStorage.setOrCreate('current_playlist_data', item)
+                  })
+                }
+              })
+            }
+            .reuseId(`${playlist.name}-${index}`)
+          })
+        }
+        .visibility(this.aggregationPlaylist.length > 0 ? Visibility.Visible : Visibility.None)
+        .onAreaChange((_: Area, newValue: Area) => {
+          this.groupHeight = newValue.height as number
+        })
+
+        ListItem(){
+          Row(){
+
+            // 监控ListItemGroup高度变化，随时调整List下方补充高度，winHeight - group高度 - 标题高度 - 避让高度
+            Blank().height(this.getBlankHeight())
+          }
+        }
+      }
+
+      // 底部空白区域
+      ListItem() {
+        Column() {
+          Blank().height(StyleConstants.PLAYER_CONTROL_HEIGHT + this.bottomRect)
+        }
+      }
+    }
+    .backToTop(true)
+    .width(StyleConstants.FULL_WIDTH)
+    .height(StyleConstants.FULL_HEIGHT)
+    .layoutWeight(1)
+    .edgeEffect(EdgeEffect.Spring)
+    .scrollBar(BarState.Off)
+    .onWillScroll(this.scrollController.scrollHandlers.onWillScroll)
+    .onScrollStop(this.scrollController.scrollHandlers.onScrollStop)
+  }
+
+  onMenuIconClick(index: number) {
+    if (index === 0 && this.pageStack.size() > 1) {
+      this.pageStack.pop()
+    }
+  }
+
+  @Builder
+  CustomTextBuilder() {
+    AddAggregationPlaylist({
+      playlistName: this.playlistName,
+      playlistDesc: this.playlistDesc
+    })
+  }
+
+  @Builder
+  AddButton() {
+    Button({ type: ButtonType.Circle }){
+      Text('󰀵')
+        .fontColor($r('app.color.text_title'))
+        .fontSize(36)
+        .fontWeight(700)
+
+    }
+    .backgroundColor($r('app.color.card_background'))
+    .backgroundBlurStyle(BlurStyle.BACKGROUND_THICK)
+    .width(48)
+    .height(48)
+    .margin({
+      right: 25,
+      bottom: (this.bottomRect/2+StyleConstants.PLAYER_CONTROL_HEIGHT+25)
+    })
+    .onClick(() => {
+      let options: CustomContentOptions = {
+        title: $r('app.string.create_playlist'),
+        contentBuilder: (): void => {
+          this.CustomTextBuilder()
+        },
+        onAction: (action) => {
+          if(action === DialogAction.TWO){
+            this.createAggregationPlaylist()
+          }else{
+            PreferencesCache.clearPlaylistsCache('aggregation_playlist')
+          }
+        }
+      }
+      DialogHelper.showCustomContentDialog(options)
+    })
+  }
+
+  getBlankHeight(): Length {
+    let sub = this.winHeight - this.groupHeight - 50 - (this.bottomRect+this.topRect)
+    return sub > 0 ? sub : 0
+  }
+
+  createAggregationPlaylist(){
+    try {
+      const timestamp: number = new Date().getTime();
+      const playlistName = this.playlistName ?? ''
+      const playListDesc = this.playlistDesc ?? ''
+      const playlistCover = this.playlistCover
+      const playlist: Playlist = {
+        id: `aggregation_playlist-${timestamp}`,
+        name: playlistName,
+        description: playListDesc,
+        cover: playlistCover,
+        size: 0,
+        type: PlaylistType.AGGREGATION
+      }
+      PreferencesCache.addPlaylistsCache('aggregation_playlist', [playlist])
+      this.playlistName = ''
+      this.playlistDesc = ''
+      LogUtil.info(`[${TAG}]`, `歌单[${this.playlistName}]添加成功`)
+    } catch(error) {
+      LogUtil.info(`[${TAG}]`, `歌单[${this.playlistName}]添加失败: ${JSON.stringify(error)}`)
+    }
+  }
+}

--- a/entry/src/main/ets/view/Library.ets
+++ b/entry/src/main/ets/view/Library.ets
@@ -78,7 +78,7 @@ struct Library {
   aboutToAppear(): void {
     this.uiContext = this.getUIContext();
     if (this.playlists[1]?.cover){
-      FormUtils.updateRecommendedCards(this.playlists[1].cover)
+      FormUtils.updateRecommendedCards(this.playlists[1].cover as string)
     }
   }
 

--- a/entry/src/main/ets/view/Personalized_settings.ets
+++ b/entry/src/main/ets/view/Personalized_settings.ets
@@ -60,6 +60,11 @@ export struct Personalized_settings_Component {
       PreferencesCache.setUserPreference(this.setUserPreference_name, this.text_ctrl)
       AppStorage.setOrCreate('miniplaying_bottom_judge', this.text_ctrl)
     }
+
+    if(this.setUserPreference_name === 'double_tap_switch_songs'){
+      PreferencesCache.setUserPreference(this.setUserPreference_name, this.text_ctrl)
+      AppStorage.setOrCreate('double_tap_switch_songs', this.text_ctrl)
+    }
   }
 }
 
@@ -67,7 +72,7 @@ export struct Personalized_settings_Component {
 @Component
 export struct Personalized_settings{
   @Consume('NavPathStack') pageStack: NavPathStack;
-  @State HorizontalMode_ctrl:string =  PreferencesCache.getUserPreference('HorizontalMode_ctrl','0')
+  @State HorizontalMode_ctrl:string =  PreferencesCache.getUserPreference('HorizontalMode_ctrl','1')
   @StorageProp('bottomRect') bottomRect: number = 0
   @Builder
   HorizontalMode_Ctrl(){
@@ -114,9 +119,11 @@ export struct Personalized_settings{
           ListItem(){ Personalized_settings_Component({text_name: ResourceManager.getStringValueSync($r('app.string.swipe_cover_switch_songs')), setUserPreference_name:'img_playing_ctrl'})}
           ListItem(){ Personalized_settings_Component({text_name: ResourceManager.getStringValueSync($r('app.string.simultaneous_playback')), setUserPreference_name:'playing_mix'})}
           ListItem(){ Personalized_settings_Component({text_name: ResourceManager.getStringValueSync($r('app.string.enable_sidebar_ui')), setUserPreference_name:'zhishi_UI'})}
+          ListItem(){ Personalized_settings_Component({text_name: ResourceManager.getStringValueSync($r('app.string.double_tap_switch_songs')), setUserPreference_name:'double_tap_switch_songs'})}
           // ListItem(){ Personalized_settings_Component({text_name: ResourceManager.getStringValueSync($r('app.string.Lyic_desktop')), setUserPreference_name:'Lyic_desktop'})}
           ListItem(){ Column().height(16+this.bottomRect/2)}
         }
+        .scrollBar(BarState.Off)
         .width('100%')
         .height('100%')
       }

--- a/entry/src/main/ets/view/Playing.ets
+++ b/entry/src/main/ets/view/Playing.ets
@@ -21,6 +21,7 @@ import ImageUtils from '../util/ImageUtils';
 import { curves, promptAction } from '@kit.ArkUI'
 import { PipManager } from '../util/PipManager'
 import WindowUtil from '../util/WindowUtil'
+import SensorUtil from '../util/SensorUtil'
 
 
 @Builder
@@ -52,6 +53,7 @@ struct Playing {
   @State imageColorHex:string='1a2a3a'
   @State currentIndex: number = -1
   @StorageLink('Lyic_desktop') Lyic_desktop: string = PreferencesCache.getUserPreference('Lyic_desktop','0')
+  @StorageProp('double_tap_switch_songs') isOnDoubleTap: string = PreferencesCache.getUserPreference('double_tap_switch_songs','0')
   // 独立的按钮动画状态
   @State swipeOffset: number = 0; // 滑动偏移量
   @State isSwipingActive: boolean = false; // 是否正在滑动中
@@ -711,11 +713,18 @@ struct Playing {
       WindowUtil.setSystemBarEnabled(this.windowStage, true)
     }
     WindowUtil.setWindowScreenOn(this.windowStage, true)
+
+    if(this.isOnDoubleTap === '1'){
+      SensorUtil.onAccelerometer()
+    }
   }
 
   aboutToDisappear() {
     WindowUtil.setSystemBarEnabled(this.windowStage, true)
     WindowUtil.setWindowScreenOn(this.windowStage, false)
+    if(this.isOnDoubleTap === '1'){
+      SensorUtil.offAccelerometer()
+    }
     if (this.updateTimer !== -1) {
       clearInterval(this.updateTimer)
       this.updateTimer = -1

--- a/entry/src/main/ets/view/Playing.ets
+++ b/entry/src/main/ets/view/Playing.ets
@@ -96,7 +96,7 @@ struct Playing {
   private swiperController: SwiperController = new SwiperController()
   // 歌曲封面-歌词翻转
   @State flipCoverLyric: boolean = PreferencesCache.flipCoverLyric()
-  @State  Pura_X:string =  PreferencesCache.getUserPreference('is_Pura_X', '0')//pura_x尝试适配
+  @State Pura_X: string = PreferencesCache.getUserPreference('is_Pura_X', '0')//pura_x尝试适配
   // 监听屏幕断点变化
   onBreakpointChange() {
     this.isWideScreen = this.currentBreakpoint !== BreakpointConstants.BREAKPOINT_SM;
@@ -452,13 +452,13 @@ struct Playing {
           LyricsView({
             mode_judge: false
           })
-            .width(StyleConstants.FULL_WIDTH)
+            .width('95%')
             .height(StyleConstants.SEVENTY_HEIGHT)
 
           Column(){
             this.PlayerControls(this.Pura_X === '1' ? false : true)
           }
-          .width('90%')
+          .width('100%')
           .layoutWeight(1)
 
           Blank()
@@ -466,7 +466,7 @@ struct Playing {
           Column(){
             this.ProgressBar(true, 0, false)
           }
-          .width('90%')
+          .width('100%')
           .layoutWeight(0.6)
 
         }
@@ -577,13 +577,13 @@ struct Playing {
           Column(){
             this.ProgressBar(false)
           }
-          .width('100%')
+          .width('120%')
           .layoutWeight(0.5)
 
           Column(){
             this.PlayerControls(this.Pura_X === '1' ? false : true)
           }
-          .width('100%')
+          .width('120%')
           .layoutWeight(1)
         }
         .padding({
@@ -710,10 +710,12 @@ struct Playing {
     }else{
       WindowUtil.setSystemBarEnabled(this.windowStage, true)
     }
+    WindowUtil.setWindowScreenOn(this.windowStage, true)
   }
 
   aboutToDisappear() {
     WindowUtil.setSystemBarEnabled(this.windowStage, true)
+    WindowUtil.setWindowScreenOn(this.windowStage, false)
     if (this.updateTimer !== -1) {
       clearInterval(this.updateTimer)
       this.updateTimer = -1

--- a/entry/src/main/ets/view/Playing.ets
+++ b/entry/src/main/ets/view/Playing.ets
@@ -1133,7 +1133,7 @@ struct Playing {
           DialogHelper.showSelectDialog({
             title: $r('app.string.add_to_playlist'),
             confirm: $r('app.string.back'),
-            selectedIndex: 0,
+            selectedIndex: -1,
             radioContent: this.aggregationPlaylist.map(playlist => playlist?.name),
             onCheckedChanged: (index) => {
               this.selectedIndex = index
@@ -1178,7 +1178,7 @@ struct Playing {
           DialogHelper.showSelectDialog({
             title: $r('app.string.add_to_playlist'),
             confirm: $r('app.string.back'),
-            selectedIndex: 0,
+            selectedIndex: -1,
             radioContent: this.aggregationPlaylist.map(playlist => playlist?.name),
             onCheckedChanged: (index) => {
               this.selectedIndex = index

--- a/entry/src/main/ets/view/Playing.ets
+++ b/entry/src/main/ets/view/Playing.ets
@@ -1,4 +1,4 @@
-import { Song } from '../type/Adapter'
+import { Playlist, Song } from '../type/Adapter'
 import { StyleConstants } from "../constants/StyleConstants"
 import { BreakpointConstants } from '../constants/BreakpointConstants'
 import { cover } from '../util/AdapterHelper'
@@ -22,6 +22,7 @@ import { curves, promptAction } from '@kit.ArkUI'
 import { PipManager } from '../util/PipManager'
 import WindowUtil from '../util/WindowUtil'
 import SensorUtil from '../util/SensorUtil'
+import { DialogHelper } from '@pura/harmony-dialog'
 
 
 @Builder
@@ -54,6 +55,7 @@ struct Playing {
   @State currentIndex: number = -1
   @StorageLink('Lyic_desktop') Lyic_desktop: string = PreferencesCache.getUserPreference('Lyic_desktop','0')
   @StorageProp('double_tap_switch_songs') isOnDoubleTap: string = PreferencesCache.getUserPreference('double_tap_switch_songs','0')
+  @StorageLink('aggregation_playlist') aggregationPlaylist: Playlist[] = PreferencesCache.getPlaylistCache('aggregation_playlist')
   // 独立的按钮动画状态
   @State swipeOffset: number = 0; // 滑动偏移量
   @State isSwipingActive: boolean = false; // 是否正在滑动中
@@ -81,6 +83,7 @@ struct Playing {
   @StorageLink('winHeightWithPx') @Watch('onWinWidthChange') winHeightWithPx: number = 0
   @State isSliderVisible: boolean = false
   @State isSliderVisible1: boolean = false
+  @State selectedIndex: number = 0
   private timerId: number = -1
   private resetTimer() {
     if (this.timerId !== -1) {
@@ -1124,6 +1127,29 @@ struct Playing {
           })
         }
       },
+      {
+        value: $r('app.string.add_to_playlist'),
+        action: () => {
+          DialogHelper.showSelectDialog({
+            title: $r('app.string.add_to_playlist'),
+            confirm: $r('app.string.back'),
+            selectedIndex: 0,
+            radioContent: this.aggregationPlaylist.map(playlist => playlist?.name),
+            onCheckedChanged: (index) => {
+              this.selectedIndex = index
+              if(PreferencesCache.addSongToAggregationPlaylist(this.aggregationPlaylist[this.selectedIndex], this.song!)){
+                ToastUtil.showShort(`[${this.song?.name}]存在于[${this.aggregationPlaylist[index].name}]`)
+                // if(this.playlistId === this.aggregationPlaylist[this.selectedIndex].id){
+                //   AppStorage.setOrCreate('current_playlist_data', this.aggregationPlaylist[this.selectedIndex])
+                // }
+              }else{
+                ToastUtil.showShort(`[${this.song?.name}]添加到[${this.aggregationPlaylist[index].name}]`)
+              }
+            },
+            onAction: (): void => {}
+          })
+        }
+      }
     ]
   }
 
@@ -1146,6 +1172,29 @@ struct Playing {
           })
         }
       },
+      {
+        value: $r('app.string.add_to_playlist'),
+        action: () => {
+          DialogHelper.showSelectDialog({
+            title: $r('app.string.add_to_playlist'),
+            confirm: $r('app.string.back'),
+            selectedIndex: 0,
+            radioContent: this.aggregationPlaylist.map(playlist => playlist?.name),
+            onCheckedChanged: (index) => {
+              this.selectedIndex = index
+              if(PreferencesCache.addSongToAggregationPlaylist(this.aggregationPlaylist[this.selectedIndex], this.song!)){
+                ToastUtil.showShort(`[${this.song?.name}]存在于[${this.aggregationPlaylist[index].name}]`)
+                // if(this.playlistId === this.aggregationPlaylist[this.selectedIndex].id){
+                //   AppStorage.setOrCreate('current_playlist_data', this.aggregationPlaylist[this.selectedIndex])
+                // }
+              }else{
+                ToastUtil.showShort(`[${this.song?.name}]添加到[${this.aggregationPlaylist[index].name}]`)
+              }
+            },
+            onAction: (): void => {}
+          })
+        }
+      }
     ]
   }
 

--- a/entry/src/main/ets/view/Playlist.ets
+++ b/entry/src/main/ets/view/Playlist.ets
@@ -2,7 +2,7 @@ import { AlbumCoversCarousel } from "../component/AlbumCoversCarousel";
 import { SongInfo } from "../component/SongInfo";
 import { TitleHeader } from "../component/TitleHeader";
 import { StyleConstants } from "../constants/StyleConstants";
-import { Playlist, Song } from "../type/Adapter";
+import { Playlist, PlaylistType, Song } from "../type/Adapter";
 import { BasicPrefetcher } from '@kit.ArkUI';
 import { SongDataSourcePrefetching } from "../util/SongDataSourcePrefetching";
 import { BreakpointConstants } from "../constants/BreakpointConstants";
@@ -25,8 +25,8 @@ export struct PlayList {
   @Consume('NavPathStack') pageStack: NavPathStack;
   @StorageLink("current_playlist_data") playlist: Playlist | null = null
   @Watch('onBreakpointChange') @StorageProp('currentBreakpoint') currentBreakpoint: string = 'sm'
-  private songDataSource: SongDataSourcePrefetching = new SongDataSourcePrefetching(null);
-  private prefetcher: BasicPrefetcher | null = null;
+  @State private songDataSource: SongDataSourcePrefetching = new SongDataSourcePrefetching(null);
+  @State private prefetcher: BasicPrefetcher | null = null;
   private sourceOk: boolean = false;
   private scroller: Scroller = new Scroller();
   @State isLoading: boolean = false;
@@ -219,32 +219,59 @@ export struct PlayList {
             ForEach(this.filteredSongs, (song: Song, index: number) => {
               ListItem() {
                 SongInfo({
+                  playlistId: this.playlist?.id,
                   song: song,
                   index: index,
                   active: this.song?.id === song.id,
                   highlight: this.billingIndex === index,
                   onTap: (song: Song) => {
                     this.onSongTap(song, index);
-                  }
+                  },
+                  rightSlot: () => {
+                  },
+                  isShowMenu: true
                 })
               }
               .key(`${song.id}-${index}`)
             })
           } else {
-            LazyForEach(this.songDataSource, (song: Song, index: number) => {
-              ListItem() {
-                SongInfo({
-                  song: song,
-                  index: index,
-                  active: this.song?.id === song.id,
-                  highlight: this.billingIndex === index,
-                  onTap: (song: Song) => {
-                    this.onSongTap(song, index);
-                  }
-                })
-              }
-              .key(`${song.id}-${index}`)
-            }, (song: Song, index: number) => `${song.id}-${index}`)
+            if(this.playlist?.type === PlaylistType.AGGREGATION) {
+              ForEach(this.playlist.songs, (song: Song, index: number) => {
+                ListItem() {
+                  SongInfo({
+                    playlistId: this.playlist?.id,
+                    playlistType: this.playlist?.type,
+                    song: song,
+                    index: index,
+                    active: this.song?.id === song.id,
+                    highlight: this.billingIndex === index,
+                    onTap: (song: Song) => {
+                      this.onSongTap(song, index);
+                    },
+                    isShowMenu: true
+                  })
+                }
+                .key(`${song.id}-${index}`)
+              }, (song: Song, index: number) => `${song.id}-${index}`)
+            } else {
+              LazyForEach(this.songDataSource, (song: Song, index: number) => {
+                ListItem() {
+                  SongInfo({
+                    playlistId: this.playlist?.id,
+                    playlistType: this.playlist?.type,
+                    song: song,
+                    index: index,
+                    active: this.song?.id === song.id,
+                    highlight: this.billingIndex === index,
+                    onTap: (song: Song) => {
+                      this.onSongTap(song, index);
+                    },
+                    isShowMenu: true
+                  })
+                }
+                .key(`${song.id}-${index}`)
+              }, (song: Song, index: number) => `${song.id}-${index}`)
+            }
           }
         }
         .onAreaChange((_oldValue: Area, newValue: Area) => {

--- a/entry/src/main/ets/viewmodel/HomePageMenuData.ets
+++ b/entry/src/main/ets/viewmodel/HomePageMenuData.ets
@@ -2,7 +2,7 @@ import { HomePageMenu } from "../model/HomePageMenu"
 
 
 export const HomePageMenuData = [
-  new HomePageMenu($r('app.string.song'), 'ComingSoon'),
+  new HomePageMenu($r('app.string.aggregation'), 'Aggregation'),
   new HomePageMenu($r('app.string.download'), 'Download'),
   new HomePageMenu($r('app.string.playlist'), 'Library'),
   new HomePageMenu($r('app.string.artist'), 'ComingSoon'),

--- a/entry/src/main/module.json5
+++ b/entry/src/main/module.json5
@@ -30,6 +30,9 @@
       {
         "name": "ohos.permission.VIBRATE"
       },
+      {
+        "name": "ohos.permission.ACCELEROMETER"
+      }
 //      {
 //        "name": "ohos.permission.READ_WRITE_DOWNLOAD_DIRECTORY",
 //        "reason": "$string:reason_read_write_download_directory",

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -479,6 +479,10 @@
     {
       "name": "vivid",
       "value": "Audio Vivid"
+    },
+    {
+      "name": "double_tap_switch_songs",
+      "value": "双敲后壳切歌（实验性）"
     }
   ]
 }

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -41,6 +41,10 @@
       "value": "歌曲"
     },
     {
+      "name": "aggregation",
+      "value": "聚合"
+    },
+    {
       "name": "album",
       "value": "专辑"
     },
@@ -187,6 +191,10 @@
     {
       "name": "no_download_tasks",
       "value": "暂无下载任务"
+    },
+    {
+      "name": "no_aggregation_playlist",
+      "value": "暂无聚合歌单"
     },
     {
       "name": "no_recommendations",
@@ -483,6 +491,26 @@
     {
       "name": "double_tap_switch_songs",
       "value": "双敲后壳切歌（实验性）"
+    },
+    {
+      "name": "create_playlist",
+      "value": "创建歌单"
+    },
+    {
+      "name": "edit_playlist_info",
+      "value": "编辑歌单信息"
+    },
+    {
+      "name": "add_to_playlist",
+      "value": "添加到歌单"
+    },
+    {
+      "name": "delete_playlist",
+      "value": "删除歌单"
+    },
+    {
+      "name": "delete_song",
+      "value": "删除歌曲"
     }
   ]
 }

--- a/entry/src/main/resources/en_US/element/string.json
+++ b/entry/src/main/resources/en_US/element/string.json
@@ -483,6 +483,34 @@
     {
       "name": "double_tap_switch_songs",
       "value": "Double Tap To Switch Songs"
+    },
+    {
+      "name": "aggregation",
+      "value": "Aggregation"
+    },
+    {
+      "name": "no_aggregation_playlist",
+      "value": "No Aggregation Playlists"
+    },
+    {
+      "name": "create_playlist",
+      "value": "Create Playlist"
+    },
+    {
+      "name": "edit_playlist_info",
+      "value": "Edit Playlist Info"
+    },
+    {
+      "name": "add_to_playlist",
+      "value": "Add To Playlist"
+    },
+    {
+      "name": "delete_playlist",
+      "value": "Delete The Playlist"
+    },
+    {
+      "name": "delete_song",
+      "value": "Delete The Song"
     }
   ]
 }

--- a/entry/src/main/resources/en_US/element/string.json
+++ b/entry/src/main/resources/en_US/element/string.json
@@ -479,6 +479,10 @@
     {
       "name": "vivid",
       "value": "Audio Vivid"
+    },
+    {
+      "name": "double_tap_switch_songs",
+      "value": "Double Tap To Switch Songs"
     }
   ]
 }

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -479,6 +479,34 @@
     {
       "name": "double_tap_switch_songs",
       "value": "双敲后壳切歌（实验性）"
+    },
+    {
+      "name": "aggregation",
+      "value": "聚合"
+    },
+    {
+      "name": "no_aggregation_playlist",
+      "value": "暂无聚合歌单"
+    },
+    {
+      "name": "create_playlist",
+      "value": "创建歌单"
+    },
+    {
+      "name": "edit_playlist_info",
+      "value": "编辑歌单信息"
+    },
+    {
+      "name": "add_to_playlist",
+      "value": "添加到歌单"
+    },
+    {
+      "name": "delete_playlist",
+      "value": "删除歌单"
+    },
+    {
+      "name": "delete_song",
+      "value": "删除歌曲"
     }
   ]
 }

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -475,6 +475,10 @@
     {
       "name": "enable_sidebar_ui",
       "value": "开启侧边栏UI"
+    },
+    {
+      "name": "double_tap_switch_songs",
+      "value": "双敲后壳切歌（实验性）"
     }
   ]
 }


### PR DESCRIPTION
1. [fix|pref|feat: 1.去除歌词边缘渐隐，在使用动画的情况下这会导致歌词界面闪烁；2.手机横屏播放界面微调，看看起来更顺眼；3.新增播放界面常亮。](https://github.com/Edge-Music/Core/pull/24/commits/1ce7131e14b761b373ffaac5136a81a6b0112808) 
2. [fix|feat: 1.[mm:ss]格式歌词新增支持解析；2.设备信息获取工具支持，为以后使用做铺垫](https://github.com/Edge-Music/Core/pull/24/commits/74f42d71376f7d5bda544cce89aa4f932c166884)
3. [feat: 1.歌词界面双指上下滑调整歌词偏移；2.歌词界面三指上滑偏移归0；3.删除歌词界面双指捏合/放大展示翻译歌词，改为三指下滑。](https://github.com/Edge-Music/Core/pull/24/commits/8bcbe4798cfb705a74f0f326c5b3dc5941df1a46)
4. [feat: 1.新增播放界面双敲击后壳切下一首歌（实验性）](https://github.com/Edge-Music/Core/pull/24/commits/3b9c984b0c94aa23a0031f995844e687c9e72710)
5. [fix|pref: 1.修复从侧边栏UI返回正常UI时主页错乱的问题；2.优化展开播放列表时的卡顿，去掉滚动动画，改为位置初始化](https://github.com/Edge-Music/Core/pull/24/commits/1a17c7b7a0e3e1a5f7aa47f19d7c8813d273d4f5)
6. [pref|fix: 1.侧边栏UI启用时，优化为如果不是首页会优先返回首页；2.修复处于PuraX小屏时侧边栏UI无法点击到Title栏右侧按钮](https://github.com/Edge-Music/Core/pull/24/commits/1284125c3da626b48cd75cc9ab3df75edd897bb5)
7. [pref|fix: 1.解决了系统播控拼劲全力无法切歌的问题；2.修复了歌词界面调整负偏移出现Nan的问题](https://github.com/Edge-Music/Core/pull/24/commits/bc40a5cef33b2284f2aa2b0f1f3ec8b4f621879c)
8. [fix|pref: 优化场景，原获取避让高度为在loadContent之后，由于loadContent是异步加载，获取到的值可能在windowClass载入前就获取，尝试改为在回调函数中获取避让值。](https://github.com/Edge-Music/Core/pull/24/commits/56e32aa247e1a44f5ea5ac55c50aa73298c87089)
9. [feat: 新增聚合歌单功能，支持新建聚合歌单、删除聚合歌单、向歌单内添加歌曲、从歌单内删除歌曲](https://github.com/Edge-Music/Core/pull/24/commits/1130e76eb5fd855085830d197a701f3633cc010d)