### PR TITLE
little fix & little feat

### DIFF
--- a/entry/src/main/ets/For_2in1_UI/Index_2in1.ets
+++ b/entry/src/main/ets/For_2in1_UI/Index_2in1.ets
@@ -409,7 +409,6 @@ export struct Index_page {
     .hideTitleBar(true)
     .hideBackButton(true)
     .backgroundColor($r('app.color.page_background'))
-    .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM, LayoutSafeAreaEdge.TOP])
     .keyboardShortcut(FunctionKey.F5, [], () => {
       this.initData()
     })

--- a/entry/src/main/ets/For_2in1_UI/MultiSearch_2in1.ets
+++ b/entry/src/main/ets/For_2in1_UI/MultiSearch_2in1.ets
@@ -99,7 +99,7 @@ export struct MultiSearch_2in1 {
                     type: 'Song',
                     title: "歌曲",
                     loading: this.loading,
-                  }).key('search')
+                  })
                 }
                 // 歌单
                 if(this.isNullResult(this.result.playlists)){
@@ -108,7 +108,7 @@ export struct MultiSearch_2in1 {
                     type: 'Playlist',
                     title: "歌单",
                     loading: this.loading,
-                  }).key('search')
+                  })
                 }
                 // 艺人
                 if(this.isNullResult(this.result.artists)){
@@ -118,7 +118,7 @@ export struct MultiSearch_2in1 {
                     title: "歌手",
                     loading: this.loading,
                     radius: "100%",
-                  }).key('search')
+                  })
                 }
                 // 专辑
                 if(this.isNullResult(this.result.albums)){
@@ -127,7 +127,7 @@ export struct MultiSearch_2in1 {
                     type: 'Album',
                     title: "专辑",
                     loading: this.loading,
-                  }).key('search')
+                  })
                 }
                 // 如果结果为空
                 if(this.nullResultFlag){

--- a/entry/src/main/ets/For_2in1_UI/MultiSearch_2in1.ets
+++ b/entry/src/main/ets/For_2in1_UI/MultiSearch_2in1.ets
@@ -184,7 +184,6 @@ export struct MultiSearch_2in1 {
     .mode(NavDestinationMode.STANDARD)
     .width(StyleConstants.FULL_WIDTH)
     .height(StyleConstants.FULL_HEIGHT)
-    .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM, LayoutSafeAreaEdge.TOP])
   }
 
   /**

--- a/entry/src/main/ets/For_2in1_UI/Playlist_2in1.ets
+++ b/entry/src/main/ets/For_2in1_UI/Playlist_2in1.ets
@@ -674,7 +674,7 @@ export struct PlayListFor2in1 {
           value: $r('app.string.download_all_songs'),
           action: () => {
             if (this.playlist?.songs && this.playlist.songs.length > 0) {
-              ToastUtil.showToast("开始下载全部歌曲")
+              ToastUtil.showToast("开始下载全部歌曲", { alignment: Alignment.Bottom, offset: { dx: 0, dy: -this.winHeight/4 } })
               const songs = this.playlist.songs.filter(song => song.privilege.playable)
               SongDownloadManager.batchDownloadSongs(songs)
             }
@@ -764,7 +764,7 @@ export struct PlayListFor2in1 {
           value: $r('app.string.download_all_songs'),
           action: () => {
             if (this.playlist?.songs && this.playlist.songs.length > 0) {
-              ToastUtil.showToast("开始下载全部歌曲")
+              ToastUtil.showToast("开始下载全部歌曲", { alignment: Alignment.Bottom, offset: { dx: 0, dy: -this.winHeight/4 } })
               const songs = this.playlist.songs.filter(song => song.privilege.playable)
               SongDownloadManager.batchDownloadSongs(songs)
             }

--- a/entry/src/main/ets/For_2in1_UI/Setting_for2in1.ets
+++ b/entry/src/main/ets/For_2in1_UI/Setting_for2in1.ets
@@ -593,12 +593,13 @@ export struct Setting_2in1 {
         .onClick(() => {
           DialogUtil.showPrimaryDialog({
             title: $r('app.string.delete_data_source'),
-            message: ResourceManager.getStringValueSync($r('app.string.whether_to_delete_data_source')) +`[${adapter.name}]？`,
+            message: ResourceManager.getStringValueSync($r('app.string.whether_to_delete_data_source')) +`[${adapter.name}]？`+ResourceManager.getStringValueSync($r('app.string.delete_source_desc')),
             primaryButton: $r('app.string.cancel'),
             secondaryButton: $r('app.string.delete'),
             onAction: (action) => {
               if (action == DialogAction.TWO) {
                 PreferencesCache.deleteUserDataSource(adapter.id)
+                PreferencesCache.deleteSongsOfAggregationPlaylists(adapter.id)
                 PreferencesCache.deleteShowUserDataSource(adapter.id)
                 ToastUtil.showShort($r('app.string.data_source_deleted'))
               }

--- a/entry/src/main/ets/For_2in1_UI/Setting_for2in1.ets
+++ b/entry/src/main/ets/For_2in1_UI/Setting_for2in1.ets
@@ -768,7 +768,6 @@ export struct Setting_2in1 {
       detents:this.Pura_X? [SheetSize.LARGE]:[SheetSize.MEDIUM],
       preferType: this.currentBreakpoint === BreakpointConstants.BREAKPOINT_SM ? SheetType.BOTTOM : SheetType.CENTER
     })
-    .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM, LayoutSafeAreaEdge.TOP])
   }
 
   getBlankHeight(): Length {

--- a/entry/src/main/ets/adapter/index.ets
+++ b/entry/src/main/ets/adapter/index.ets
@@ -516,7 +516,15 @@ export class SourceAdapter {
 
   static async getSongDetail(song: Song, br: Bitrate = PreferencesCache.playingLevel()): Promise<Song> {
     try {
-      const source = song.source as SourceConfig;
+      // 兼容本地聚合歌单和在线歌单，优先获取Song中的sourceID，从数据源中查找符合的
+      const adapters = AppStorage.get<SourceConfig[]>('user_data_source') as SourceConfig[]
+      let source: SourceConfig
+      if(song.sourceID) {
+        source = adapters.find((item) => item.id === song.sourceID) as SourceConfig
+      } else {
+        source = song.source as SourceConfig;
+      }
+      LogUtil.info(`[${TAG}]`, `Song Source.id: ${song.sourceID} and source.id: ${source.id}`)
       const uid = song.source?.auth?.user?.id;
       const request = createRequest(source);
       const bitRate = song.privilege?.bitrates;

--- a/entry/src/main/ets/component/Cover.ets
+++ b/entry/src/main/ets/component/Cover.ets
@@ -1,7 +1,5 @@
 import { StyleConstants } from "../constants/StyleConstants"
 
-
-@Reusable
 @Component
 export struct Cover {
   loading?: boolean = false
@@ -10,7 +8,7 @@ export struct Cover {
   menuItems?: MenuElement[] = []
   src: ResourceStr = ''
   radius: number | string = 8
-  titleAlign: HorizontalAlign = HorizontalAlign.Start
+  titleAlign: TextAlign = TextAlign.Start
 
   @Builder
   MoreButton() {
@@ -78,6 +76,7 @@ export struct Cover {
               .maxLines(1)
               .textOverflow({ overflow: TextOverflow.Ellipsis })
               .heightAdaptivePolicy(TextHeightAdaptivePolicy.MAX_LINES_FIRST)
+              .textAlign(this.titleAlign)
           }
 
           if (this.subTitle) {
@@ -89,10 +88,12 @@ export struct Cover {
               .maxLines(1)
               .textOverflow({ overflow: TextOverflow.Ellipsis })
               .heightAdaptivePolicy(TextHeightAdaptivePolicy.MAX_LINES_FIRST)
+              .textAlign(this.titleAlign)
           }
         }
       }
-      .alignItems(this.titleAlign)
+      .alignItems(HorizontalAlign.Center)
+      .justifyContent(FlexAlign.Center)
       .width(StyleConstants.FULL_WIDTH)
     }
     .clickEffect({ level: ClickEffectLevel.LIGHT })

--- a/entry/src/main/ets/component/CustomTextBuilder.ets
+++ b/entry/src/main/ets/component/CustomTextBuilder.ets
@@ -29,7 +29,7 @@ export struct AddAggregationPlaylist {
             Text($r('app.string.playlist_description'))
               .fontSize(16)
               .fontWeight(700)
-              .margin({ left: 16 })
+              .margin({ left: 14 })
             TextArea({ placeholder: $r('app.string.playlist_desc_placeholder'), text: this.playlistDesc })
               .width('100%')
               .height(120)

--- a/entry/src/main/ets/component/CustomTextBuilder.ets
+++ b/entry/src/main/ets/component/CustomTextBuilder.ets
@@ -9,11 +9,11 @@ export struct AddAggregationPlaylist {
       List({ space: 10 }){
         ListItem(){
           Column(){
-            Text('歌单名称')
+            Text($r('app.string.playlist_name'))
               .fontSize(16)
               .fontWeight(700)
               .margin({ left: 14 })
-            TextInput({ placeholder: '请输入歌单名称', text: this.playlistName })
+            TextInput({ placeholder: $r('app.string.playlist_name_placeholder'), text: this.playlistName })
               .width('100%')
               .margin({ top: 5 })
               .onChange((value: string) => {
@@ -26,11 +26,11 @@ export struct AddAggregationPlaylist {
 
         ListItem(){
           Column() {
-            Text('歌单描述')
-              .fontSize(14)
+            Text($r('app.string.playlist_description'))
+              .fontSize(16)
               .fontWeight(700)
               .margin({ left: 16 })
-            TextArea({ placeholder: '请输入歌单描述', text: this.playlistDesc })
+            TextArea({ placeholder: $r('app.string.playlist_desc_placeholder'), text: this.playlistDesc })
               .width('100%')
               .height(120)
               .margin({ top: 5 })

--- a/entry/src/main/ets/component/HorizontalScroll.ets
+++ b/entry/src/main/ets/component/HorizontalScroll.ets
@@ -8,6 +8,7 @@ import { cover } from "../util/AdapterHelper"
 import { PlaylistManager } from "../util/PlaylistManager"
 import { PreferencesCache } from "../util/PreferenceCache"
 import { PushPathHelper } from "../util/PushPathHelper"
+import { SongDownloadManager } from "../util/SongDownloadManager"
 import { Cover } from "./Cover"
 
 const DEFAULT_COVER_SIZE = 256
@@ -230,6 +231,12 @@ export struct HorizontalScroll {
             onAction: (): void => {}
           })
         }
+      },
+      {
+        value: $r('app.string.download_this_song'),
+        action: () => {
+          this.downloadSong(song)
+        }
       }
     ]
   }
@@ -249,7 +256,44 @@ export struct HorizontalScroll {
             PlaylistManager.loadPlaylist(songs, songs[0])
           })
         }
+      },
+      {
+        value: $r('app.string.add_to_play_next'),
+        action: () => {
+          PushPathHelper.loading("Playing", async () => {
+            const playlistDetail = await SourceAdapter.getPlaylistDetail(playlist)
+            const songs = playlistDetail?.songs?.filter(song => song.privilege.playable)
+            if (!songs || songs.length === 0) {
+              ToastUtil.showShort("此歌单无可播放歌曲")
+              return
+            }
+            PlaylistManager.insertSongs(songs)
+          })
+        }
+      },
+      {
+        value: $r('app.string.download_all_songs'),
+        action: () => {
+          if (playlist?.songs && playlist.songs.length > 0) {
+            const songs = playlist.songs.filter(song => song.privilege.playable)
+            SongDownloadManager.batchDownloadSongs(songs)
+          }
+        }
       }
     ]
+  }
+
+  async downloadSong(song: Song) {
+    if (song) {
+      ToastUtil.showShort($r('app.string.added_to_the_download_queue'))
+      SongDownloadManager.downloadSong(
+        song.id.toString(),
+        song,
+        undefined,
+        () => {
+          ToastUtil.showShort($r('app.string.download_successful'))
+        },
+      )
+    }
   }
 }

--- a/entry/src/main/ets/component/HorizontalScroll.ets
+++ b/entry/src/main/ets/component/HorizontalScroll.ets
@@ -64,7 +64,7 @@ export struct HorizontalScroll {
 
   @Builder
   TemplateCover(){
-    ForEach([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], () => {
+    ForEach([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20], () => {
       ListItem(){
         Cover({
           loading: true,
@@ -75,7 +75,7 @@ export struct HorizontalScroll {
           .width(120)
           .padding(4)
       }
-      .key('Template')
+      .reuseId('Template')
     })
   }
 
@@ -99,7 +99,7 @@ export struct HorizontalScroll {
               })
             })
         }
-        .key(`${item.name}-${index}`)
+        .reuseId(`${item.name}-${index}`)
       })
     }
     .width('100%')
@@ -118,7 +118,7 @@ export struct HorizontalScroll {
             src: cover(item.avatar, DEFAULT_COVER_SIZE),
             title: item.name,
             radius: "100%",
-            titleAlign: HorizontalAlign.Center
+            titleAlign: TextAlign.Center
           })
             .width(this.coverWidth)
             .padding(this.segmentPadding)
@@ -130,7 +130,7 @@ export struct HorizontalScroll {
               })
             })
         }
-        .key(`${item.name}-${index}`)
+        .reuseId(`${item.name}-${index}`)
       })
     }
     .width('100%')
@@ -161,7 +161,7 @@ export struct HorizontalScroll {
 
             })
         }
-        .key(`${item.name}-${index}`)
+        .reuseId(`${item.name}-${index}`)
       })
     }
     .width('100%')
@@ -190,7 +190,7 @@ export struct HorizontalScroll {
               })
             })
         }
-        .key(`${item.name}-${index}`)
+        .reuseId(`${item.name}-${index}`)
       })
     }
     .width('100%')

--- a/entry/src/main/ets/component/LyricsView.ets
+++ b/entry/src/main/ets/component/LyricsView.ets
@@ -1,34 +1,37 @@
 import { StyleConstants } from "../constants/StyleConstants";
 import { avPlayerManager } from "../util/AVPlayerManager";
 import { PreferencesCache } from "../util/PreferenceCache";
-import { App, LengthMetrics, LengthUnit } from '@kit.ArkUI'
 import LyricsManager, { LyricsLine } from "../util/LyricsManager";
 import { VibrationControl } from "../util/DeviceController";
 import { EventHelper } from "../util/EventHelper";
 import { LyricItem } from "./LyricItem";
-import { LogUtil, ToastUtil } from "@pura/harmony-utils";
+import { ToastUtil } from "@pura/harmony-utils";
 
 @Component
 export struct LyricsView {
-  @StorageProp('leftCutoutRectWidth') leftCutoutRectWidth: number = 0
-  @StorageProp('rightCutoutRectWidth') rightCutoutRectWidth: number = 0
-  @StorageProp('current_parsed_lyrics') private parsedLyrics: Array<LyricsLine> = []
-  @StorageLink('current_lyrics_index') @Watch("onTimeUpdate") private currentLyricsIndex: number = 0
-  @State mode_judge: boolean = false
-  @State private showTranslation: boolean = PreferencesCache.showTranslationLyric()
-  @StorageProp('current_lyrics_has_translation') private hasTranslation: boolean = false // 是否有翻译歌词
-  @StorageProp('current_lyrics_has_transliteration') private hasTransliteration: boolean = false
   private scroller: Scroller = new Scroller()
   private readonly SCROLL_ANIMATION_DURATION: number = 600
   private lastTriggerTime: number = 0;
+  private uiContext: UIContext | undefined = undefined;
+
+  @StorageProp('leftCutoutRectWidth') leftCutoutRectWidth: number = 0
+  @StorageProp('rightCutoutRectWidth') rightCutoutRectWidth: number = 0
+  @StorageProp('current_parsed_lyrics') private parsedLyrics: Array<LyricsLine> = []
+  @StorageProp('current_lyrics_has_translation') private hasTranslation: boolean = false // 是否有翻译歌词
+  @StorageProp('current_lyrics_has_transliteration') private hasTransliteration: boolean = false
+  @StorageProp('winHeight') winHeight: number = 0
+  @StorageLink('current_lyrics_index') @Watch("onTimeUpdate") private currentLyricsIndex: number = 0
+
   @State private manualScrollTimeoutId: number = -1; // 手动滚动超时ID
   @State private isManualScroll: boolean = false; // 是否处于手动滚动状态
   @State private isAutoScroll: boolean = false; // 是否处于自动滚动状态
   @State private currentLyricsOffsetTime: number = PreferencesCache.currentLyricsOffsetTime()
   @State private lastLyricsOffsetTime: number = PreferencesCache.currentLyricsOffsetTime()
   @State private lastStep: number = 0
-  @State private isShow: boolean = false;
-  uiContext: UIContext | undefined = undefined;
+  @State private isShow: boolean = false
+  @State mode_judge: boolean = false
+  @State private showTranslation: boolean = PreferencesCache.showTranslationLyric()
+
   aboutToAppear() {
     this.uiContext = this.getUIContext();
     this.scrollToLyric(this.currentLyricsIndex)
@@ -101,8 +104,7 @@ export struct LyricsView {
         } else {
           List({
             initialIndex: this.getTargetIndex(this.currentLyricsIndex),
-            scroller: this.scroller,
-            space: 12
+            scroller: this.scroller
           }) {
             ForEach(this.parsedLyrics, (item: LyricsLine, index) => {
               ListItem() {
@@ -113,11 +115,11 @@ export struct LyricsView {
                   currentLyricsIndex: this.currentLyricsIndex,
                 })
               }
+              .width(StyleConstants.FULL_WIDTH)
               .key('lyricItem'+index)
               .onClick(() => {
                 this.handleLyricClick(item.time, index)
               })
-              .width(StyleConstants.FULL_WIDTH)
             })
           }
           .width(StyleConstants.FULL_WIDTH)
@@ -177,7 +179,7 @@ export struct LyricsView {
       }
       .alignItems(HorizontalAlign.Center)
       .justifyContent(FlexAlign.Center)
-      .margin({ bottom: '30%' })
+      .margin({ bottom: this.winHeight*0.30 })
       .backgroundBlurStyle(BlurStyle.BACKGROUND_THICK)
       .height(60)
       .width(200)
@@ -199,7 +201,7 @@ export struct LyricsView {
               this.currentLyricsOffsetTime = 0
               this.lastLyricsOffsetTime = 0
               VibrationControl.handlePresetVibration(1)
-              ToastUtil.showToast(`当前歌词偏移：${this.currentLyricsOffsetTime}MS`)
+              ToastUtil.showToast(`当前歌词偏移：${this.currentLyricsOffsetTime}MS`, { alignment: Alignment.Bottom, offset: { dx: 0, dy: -this.winHeight/4 } })
             }
             if(currentStep > 1){
               if(this.hasTranslation || this.hasTransliteration){
@@ -225,7 +227,7 @@ export struct LyricsView {
             this.lastStep = 0
             this.isShow = false
             this.lastLyricsOffsetTime = this.currentLyricsOffsetTime
-            ToastUtil.showToast(`当前歌词偏移：${this.currentLyricsOffsetTime}MS`)
+            ToastUtil.showToast(`当前歌词偏移：${this.currentLyricsOffsetTime}MS`, { alignment: Alignment.Bottom, offset: { dx: 0, dy: -this.winHeight/4 } })
           }),
 
       )
@@ -235,7 +237,7 @@ export struct LyricsView {
   handleUpdate(newStep: number): boolean {
     if (newStep !== this.lastStep) {
       this.lastStep = newStep
-      return true // 需要触发震动
+      return true
     }
     return false
   }

--- a/entry/src/main/ets/component/PlaylistItem.ets
+++ b/entry/src/main/ets/component/PlaylistItem.ets
@@ -16,6 +16,7 @@ const TAG = 'PlaylistItem'
 export struct PlaylistItem {
   @State playlistName: string | undefined = undefined
   @State playlistDesc: string | undefined = undefined
+  @State isShowMenu: boolean = false
   @Prop playlist: Playlist
   onPlaylistSelected?: (playlist: Playlist) => void;
 
@@ -28,6 +29,7 @@ export struct PlaylistItem {
           .height(58)
           .objectFit(ImageFit.Cover)
           .borderRadius(8)
+          .draggable(false)
       }
       .margin({ right: 12 })
 
@@ -60,7 +62,17 @@ export struct PlaylistItem {
       }
       .width(48)
       .height(48)
-      .bindMenu(this.generatePlaylistMenu(this.playlist))
+      .bindMenu(
+        this.isShowMenu,
+        this.generatePlaylistMenu(this.playlist),
+        {
+          onDisappear: () => {
+            this.isShowMenu = false
+         }
+      })
+      .onClick(() => {
+        this.isShowMenu = true
+      })
       .clickEffect({ level: ClickEffectLevel.LIGHT })
       .stateStyles({
         pressed: this.pressedStyles,
@@ -77,6 +89,15 @@ export struct PlaylistItem {
         this.onPlaylistSelected(this.playlist);
       }
     })
+    .gesture(
+      LongPressGesture({
+        fingers: 1,
+        repeat: false
+      })
+        .onAction(() => {
+          this.isShowMenu = true
+        })
+    )
     .clickEffect({ level: ClickEffectLevel.LIGHT })
     .animation({ duration: 300, curve: Curve.LinearOutSlowIn })
   }

--- a/entry/src/main/ets/component/PlaylistItem.ets
+++ b/entry/src/main/ets/component/PlaylistItem.ets
@@ -8,6 +8,7 @@ import { PlaylistManager } from "../util/PlaylistManager";
 import { PreferencesCache } from "../util/PreferenceCache";
 import { PushPathHelper } from "../util/PushPathHelper";
 import ResourceManager from "../util/ResourceManager";
+import { SongDownloadManager } from "../util/SongDownloadManager";
 import { AddAggregationPlaylist } from "./CustomTextBuilder";
 const TAG = 'PlaylistItem'
 
@@ -144,6 +145,15 @@ export struct PlaylistItem {
           }
         },
         {
+          value: $r('app.string.download_all_songs'),
+          action: () => {
+            if (this.playlist?.songs && this.playlist.songs.length > 0) {
+              const songs = this.playlist.songs.filter(song => song.privilege.playable)
+              SongDownloadManager.batchDownloadSongs(songs)
+            }
+          }
+        },
+        {
           value: $r('app.string.edit_playlist_info'),
           action: () => {
             let options: CustomContentOptions = {
@@ -207,6 +217,15 @@ export struct PlaylistItem {
               PlaylistManager.insertSongs(songs)
             })
           }
+        },
+        {
+          value: $r('app.string.download_all_songs'),
+          action: () => {
+            if (this.playlist?.songs && this.playlist.songs.length > 0) {
+              const songs = this.playlist.songs.filter(song => song.privilege.playable)
+              SongDownloadManager.batchDownloadSongs(songs)
+            }
+          }
         }
       ]
     }
@@ -248,4 +267,5 @@ export struct PlaylistItem {
       playlistDesc: this.playlistDesc
     })
   }
+
 }

--- a/entry/src/main/ets/component/PlaylistItem.ets
+++ b/entry/src/main/ets/component/PlaylistItem.ets
@@ -193,11 +193,12 @@ export struct PlaylistItem {
   updateAggregationPlaylist(playlist: Playlist) {
     try {
       PreferencesCache.updatePlaylistsCache('aggregation_playlist', playlist, this.playlistName, this.playlistDesc)
-      this.playlistName = ''
-      this.playlistDesc = ''
       LogUtil.info(`[${TAG}]`, `歌单[${this.playlistName}]更新成功`)
     } catch(error) {
       LogUtil.info(`[${TAG}]`, `歌单[${this.playlistName}]更新失败: ${JSON.stringify(error)}`)
+    } finally {
+      this.playlistName = ''
+      this.playlistDesc = ''
     }
   }
 

--- a/entry/src/main/ets/component/PlaylistItem.ets
+++ b/entry/src/main/ets/component/PlaylistItem.ets
@@ -7,14 +7,15 @@ import { cover } from "../util/AdapterHelper";
 import { PlaylistManager } from "../util/PlaylistManager";
 import { PreferencesCache } from "../util/PreferenceCache";
 import { PushPathHelper } from "../util/PushPathHelper";
+import ResourceManager from "../util/ResourceManager";
 import { AddAggregationPlaylist } from "./CustomTextBuilder";
 const TAG = 'PlaylistItem'
 
 @Reusable
 @Component
 export struct PlaylistItem {
-  @State playlistName: string | undefined = ''
-  @State playlistDesc: string | undefined = ''
+  @State playlistName: string | undefined = undefined
+  @State playlistDesc: string | undefined = undefined
   @Prop playlist: Playlist
   onPlaylistSelected?: (playlist: Playlist) => void;
 
@@ -191,14 +192,20 @@ export struct PlaylistItem {
   }
 
   updateAggregationPlaylist(playlist: Playlist) {
+    let playlistName: string = this.playlistName?.trim() && this.playlistName.trim() !== '' ? this.playlistName.trim() : ResourceManager.getStringValueSync($r('app.string.default_playlist_name'))
+    let playlistDesc: string = this.playlistDesc?.trim() && this.playlistDesc?.trim() !== '' ? this.playlistDesc?.trim() : ResourceManager.getStringValueSync($r('app.string.default_playlist_desc'))
     try {
-      PreferencesCache.updatePlaylistsCache('aggregation_playlist', playlist, this.playlistName, this.playlistDesc)
-      LogUtil.info(`[${TAG}]`, `歌单[${this.playlistName}]更新成功`)
+      PreferencesCache.updatePlaylistsCache(
+        'aggregation_playlist',
+        playlist,
+        playlistName,
+        playlistDesc)
+      LogUtil.info(`[${TAG}]`, `歌单[${playlist.id}][${playlistName}]更新成功`)
     } catch(error) {
-      LogUtil.info(`[${TAG}]`, `歌单[${this.playlistName}]更新失败: ${JSON.stringify(error)}`)
+      LogUtil.info(`[${TAG}]`, `歌单[${playlist.id}][${this.playlistName}]更新失败: ${JSON.stringify(error)}`)
     } finally {
-      this.playlistName = ''
-      this.playlistDesc = ''
+      this.playlistName = undefined
+      this.playlistDesc = undefined
     }
   }
 
@@ -206,10 +213,10 @@ export struct PlaylistItem {
     try {
       PreferencesCache.deletePlaylistCache('aggregation_playlist', playlist)
       ToastUtil.showShort("成功删除歌单")
-      LogUtil.info(`[${TAG}]`, `歌单[${playlist.name}]删除成功`)
+      LogUtil.info(`[${TAG}]`, `歌单[${playlist.id}][${playlist.name}]删除成功`)
     } catch(error) {
       ToastUtil.showShort("删除歌单失败!")
-      LogUtil.info(`[${TAG}]`, `歌单[${playlist.name}]删除失败: ${JSON.stringify(error)}`)
+      LogUtil.info(`[${TAG}]`, `歌单[${playlist.id}][${playlist.name}]删除失败: ${JSON.stringify(error)}`)
     }
   }
 

--- a/entry/src/main/ets/component/SongInfo.ets
+++ b/entry/src/main/ets/component/SongInfo.ets
@@ -3,6 +3,8 @@ import { LogUtil, ToastUtil } from "@pura/harmony-utils";
 import { StyleConstants } from "../constants/StyleConstants";
 import { Playlist, PlaylistType, Song } from "../type/Adapter";
 import { PreferencesCache } from "../util/PreferenceCache";
+import { SongDownloadManager } from "../util/SongDownloadManager";
+
 const TAG = 'SongInfo'
 
 @Reusable
@@ -219,6 +221,12 @@ export struct SongInfo {
               }
             })
           }
+        },
+        {
+          value: $r('app.string.download_this_song'),
+          action: () => {
+            this.downloadSong()
+          }
         }
       ]
     } else {
@@ -245,6 +253,12 @@ export struct SongInfo {
               onAction: (): void => {}
             })
           }
+        },
+        {
+          value: $r('app.string.download_this_song'),
+          action: () => {
+            this.downloadSong()
+          }
         }
       ]
     }
@@ -258,6 +272,20 @@ export struct SongInfo {
     } catch(error) {
       ToastUtil.showShort("删除歌曲失败!")
       LogUtil.info(`[${TAG}]`, `歌曲[${song.name}]删除失败: ${JSON.stringify(error)}`)
+    }
+  }
+
+  async downloadSong() {
+    if (this.song) {
+      ToastUtil.showShort($r('app.string.added_to_the_download_queue'))
+      SongDownloadManager.downloadSong(
+        this.song.id.toString(),
+        this.song,
+        undefined,
+        () => {
+          ToastUtil.showShort($r('app.string.download_successful'))
+        },
+      )
     }
   }
 

--- a/entry/src/main/ets/component/TimerSelector.ets
+++ b/entry/src/main/ets/component/TimerSelector.ets
@@ -5,6 +5,7 @@ import { EventHelper } from "../util/EventHelper"
 @Component
 export struct TimerSelector {
   @StorageLink('playing_pause_time') pauseAt: number = -1
+  @StorageProp('winHeight') winHeight: number = 0
   @State remainingTime: string = ''
   @State selectedOption: number = -1
   @State isVisible: boolean = false
@@ -271,7 +272,7 @@ export struct TimerSelector {
             if (action == DialogAction.SURE) {
               const min = parseInt(value)
               if (isNaN(min) || min <= 0) {
-                ToastUtil.showToast("请输入一个有效的分钟数")
+                ToastUtil.showToast("请输入一个有效的分钟数", { alignment: Alignment.Bottom, offset: { dx: 0, dy: -this.winHeight/4 } })
                 return
               }
               this.setTimer(min)

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -64,7 +64,6 @@ struct Index {
     .navDestination(this.PageMap)
     .hideNavBar(true)
     .mode(NavigationMode.Stack)
-    .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM, LayoutSafeAreaEdge.TOP])
   }
 }
 
@@ -466,12 +465,11 @@ struct Index_page {
     }
     .height(StyleConstants.FULL_HEIGHT)
     .width(StyleConstants.FULL_WIDTH)
-    .systemTransition(NavigationSystemTransitionType.SLIDE_RIGHT)
+    // .systemTransition(NavigationSystemTransitionType.SLIDE_RIGHT)
     .hideToolBar(true)
     .hideTitleBar(true)
     .hideBackButton(true)
     .backgroundColor($r('app.color.page_background'))
-    .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM, LayoutSafeAreaEdge.TOP])
     .onBackPressed(() => {
       if(this.page_judge !== 'index'){
         this.page_judge = 'index'

--- a/entry/src/main/ets/type/Adapter.ets
+++ b/entry/src/main/ets/type/Adapter.ets
@@ -134,6 +134,9 @@ export interface Song {
 
   // 数据来源
   source?: SourceConfig;
+
+  // 数据源ID
+  sourceID? : ID
 }
 
 export interface LyricLine {

--- a/entry/src/main/ets/util/PlaylistManager.ets
+++ b/entry/src/main/ets/util/PlaylistManager.ets
@@ -50,6 +50,7 @@ export class PlaylistManager {
     // 如果当前播放的歌曲和要播放的歌曲相同，则不做任何操作，且并不是单曲循环模式
     if (currentSong && currentSong.id === song.id && PlaylistManager.getPlayMode() !== PlayMode.SINGLE) {
       EventHelper.postSongState("PLAY")
+      await avPlayerManager.play()
       return
     } else if (currentSong && currentSong.id === song.id && PlaylistManager.getPlayMode() === PlayMode.SINGLE) {
       LogUtil.info("PlaylistManager ", "PlaySong ", "Single Loop Mode")

--- a/entry/src/main/ets/util/PreferenceCache.ets
+++ b/entry/src/main/ets/util/PreferenceCache.ets
@@ -436,6 +436,7 @@ export class PreferencesCache {
       LogUtil.info(`[${TAG}]`, `[${song.name}]已存在于歌单[${playlists[resultIndex].name}]`)
     }else{
       let item: Playlist = playlists[resultIndex]
+      song.sourceID = song.source?.id
       if(item.songs){
         playlists[resultIndex].songs?.push(song)
       }else{
@@ -447,6 +448,22 @@ export class PreferencesCache {
       AppStorage.setOrCreate('aggregation_playlist', playlists);
     }
     return isExist
+  }
+
+  static deleteSongsOfAggregationPlaylists(sourceId: ID): void{
+    let playlists: Playlist[] = JSON.parse(PreferencesCache.getCache('aggregation_playlist', '[]'));
+    playlists = playlists.map(playlist => {
+      // 过滤掉sourceId匹配的歌曲
+      const filteredSongs = playlist.songs?.filter(song => song.sourceID !== sourceId);
+      playlist.songs = filteredSongs
+      playlist.size = filteredSongs?.length
+      // 返回更新后的歌单（保持其他属性不变）
+      return playlist
+    });
+
+    LogUtil.info(`[${TAG}]`, `删除后的歌单：${JSON.stringify(playlists)}`)
+    PreferencesCache.setCache('aggregation_playlist', JSON.stringify(playlists));
+    AppStorage.setOrCreate('aggregation_playlist', playlists);
   }
 
   static clearPlaylistsCache(strIndex: string): void {

--- a/entry/src/main/ets/util/PushPathHelper.ets
+++ b/entry/src/main/ets/util/PushPathHelper.ets
@@ -50,7 +50,7 @@ export class PushPathHelper {
         }
       }
 
-      pathStack.pushPath({ name })
+      pathStack.pushPath({ name: name })
 
       if (afterFn) {
         afterFn();

--- a/entry/src/main/ets/util/RealTimeTrendDetector.ets
+++ b/entry/src/main/ets/util/RealTimeTrendDetector.ets
@@ -10,7 +10,7 @@ class StrictTrendDetector {
   private dataWindow: number[];
   private trendSequence: Trend[]; // 当前正在构建的趋势序列
 
-  constructor(windowSize: number = 20, minTrendDiff: number = 3) {
+  constructor(windowSize: number = 5, minTrendDiff: number = 3) {
     this.windowSize = windowSize;
     this.minTrendDiff = minTrendDiff;
     this.dataWindow = [];

--- a/entry/src/main/ets/view/About.ets
+++ b/entry/src/main/ets/view/About.ets
@@ -4,6 +4,8 @@ import { BusinessError } from "@kit.BasicServicesKit"
 
 @Component
 export struct About {
+  @StorageProp('winHeight') winHeight: number = 0
+
   @Builder
   AppInfo() {
     Column() {
@@ -45,7 +47,7 @@ export struct About {
           WantUtil.toWebBrowser("https://github.com/Edge-Music")
             .catch((err: BusinessError) => {
               LogUtil.error("AboutPage", "拉起失败！", err.message);
-              ToastUtil.showToast("跳转到GitHub失败！");
+              ToastUtil.showToast("跳转到GitHub失败！", { alignment: Alignment.Bottom, offset: { dx: 0, dy: -this.winHeight/4 } });
             });
         })
 
@@ -67,7 +69,7 @@ export struct About {
           WantUtil.toWebBrowser("https://music.yby.zone/")
             .catch((err: BusinessError) => {
               LogUtil.error("AboutPage", "拉起失败！", err.message);
-              ToastUtil.showToast("跳转到官网失败！");
+              ToastUtil.showToast("跳转到官网失败！", { alignment: Alignment.Bottom, offset: { dx: 0, dy: -this.winHeight/4 } });
             });
         })
       }
@@ -182,7 +184,7 @@ export struct About {
       WantUtil.toWebBrowser("https://beian.miit.gov.cn/")
         .catch((err: BusinessError) => {
           LogUtil.error("AboutPage", "拉起失败！", err.message);
-          ToastUtil.showToast("跳转到浏览器失败！");
+          ToastUtil.showToast("跳转到浏览器失败！", { alignment: Alignment.Bottom, offset: { dx: 0, dy: -this.winHeight/4 } });
         });
     })
   }

--- a/entry/src/main/ets/view/Aggregation.ets
+++ b/entry/src/main/ets/view/Aggregation.ets
@@ -111,7 +111,6 @@ export struct Aggregation {
 
         ListItem(){
           Row(){
-
             // 监控ListItemGroup高度变化，随时调整List下方补充高度，winHeight - group高度 - 标题高度 - 避让高度
             Blank().height(this.getBlankHeight())
           }
@@ -164,7 +163,7 @@ export struct Aggregation {
     .height(48)
     .margin({
       right: 25,
-      bottom: (this.bottomRect/2+StyleConstants.PLAYER_CONTROL_HEIGHT+25)
+      bottom: (this.bottomRect/2+StyleConstants.PLAYER_CONTROL_HEIGHT+40)
     })
     .onClick(() => {
       let options: CustomContentOptions = {

--- a/entry/src/main/ets/view/Aggregation.ets
+++ b/entry/src/main/ets/view/Aggregation.ets
@@ -11,6 +11,7 @@ import { PushPathHelper } from "../util/PushPathHelper";
 import { ScrollController } from "../util/ScrollController";
 import { LogUtil } from "@pura/harmony-utils";
 import { AddAggregationPlaylist } from "../component/CustomTextBuilder";
+import ResourceManager from "../util/ResourceManager";
 
 const TAG = 'Aggregation'
 
@@ -187,18 +188,20 @@ export struct Aggregation {
   }
 
   createAggregationPlaylist(){
+    let playlistName: string = this.playlistName?.trim() && this.playlistName.trim() !== '' ? this.playlistName.trim() : ResourceManager.getStringValueSync($r('app.string.default_playlist_name'))
+    let playlistDesc: string = this.playlistDesc?.trim() && this.playlistDesc?.trim() !== '' ? this.playlistDesc?.trim() : ResourceManager.getStringValueSync($r('app.string.default_playlist_desc'))
     try {
       const timestamp: number = new Date().getTime();
       const playlist: Playlist = {
         id: `aggregation_playlist-${timestamp}`,
-        name: this.playlistName?.trim() ?? '默认歌单',
-        description: this.playlistDesc?.trim() ?? '',
+        name: playlistName,
+        description: playlistDesc,
         cover: this.playlistCover,
         size: 0,
         type: PlaylistType.AGGREGATION
       }
       PreferencesCache.addPlaylistsCache('aggregation_playlist', [playlist])
-      LogUtil.info(`[${TAG}]`, `歌单[${this.playlistName}]添加成功`)
+      LogUtil.info(`[${TAG}]`, `歌单[${playlist.id}][${playlistName}]添加成功`)
       this.playlistCover = $r('app.media.icon_startwindow')
     } catch(error) {
       LogUtil.info(`[${TAG}]`, `歌单[${this.playlistName}]添加失败: ${JSON.stringify(error)}`)

--- a/entry/src/main/ets/view/Aggregation.ets
+++ b/entry/src/main/ets/view/Aggregation.ets
@@ -192,19 +192,20 @@ export struct Aggregation {
       const timestamp: number = new Date().getTime();
       const playlist: Playlist = {
         id: `aggregation_playlist-${timestamp}`,
-        name: this.playlistName ?? '默认歌单',
-        description: this.playlistDesc ?? '',
+        name: this.playlistName?.trim() ?? '默认歌单',
+        description: this.playlistDesc?.trim() ?? '',
         cover: this.playlistCover,
         size: 0,
         type: PlaylistType.AGGREGATION
       }
       PreferencesCache.addPlaylistsCache('aggregation_playlist', [playlist])
-      this.playlistName = undefined
-      this.playlistDesc = undefined
-      this.playlistCover = $r('app.media.icon_startwindow')
       LogUtil.info(`[${TAG}]`, `歌单[${this.playlistName}]添加成功`)
+      this.playlistCover = $r('app.media.icon_startwindow')
     } catch(error) {
       LogUtil.info(`[${TAG}]`, `歌单[${this.playlistName}]添加失败: ${JSON.stringify(error)}`)
+    } finally {
+      this.playlistName = undefined
+      this.playlistDesc = undefined
     }
   }
 }

--- a/entry/src/main/ets/view/Aggregation.ets
+++ b/entry/src/main/ets/view/Aggregation.ets
@@ -158,6 +158,7 @@ export struct Aggregation {
         .fontWeight(700)
 
     }
+    .clickEffect({ level: ClickEffectLevel.LIGHT })
     .backgroundColor($r('app.color.card_background'))
     .backgroundBlurStyle(BlurStyle.BACKGROUND_THICK)
     .width(48)

--- a/entry/src/main/ets/view/Download.ets
+++ b/entry/src/main/ets/view/Download.ets
@@ -149,7 +149,6 @@ export struct Download {
     .mode(NavDestinationMode.STANDARD)
     .width(StyleConstants.FULL_WIDTH)
     .height(StyleConstants.FULL_HEIGHT)
-    .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM, LayoutSafeAreaEdge.TOP])
   }
 
   getBlankHeight(): Length {

--- a/entry/src/main/ets/view/Library.ets
+++ b/entry/src/main/ets/view/Library.ets
@@ -385,7 +385,6 @@ struct Library {
     .mode(NavDestinationMode.STANDARD)
     .width(StyleConstants.FULL_WIDTH)
     .height(StyleConstants.FULL_HEIGHT)
-    .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM, LayoutSafeAreaEdge.TOP])
   }
 
   countSubVp(): number{

--- a/entry/src/main/ets/view/MultiSearch.ets
+++ b/entry/src/main/ets/view/MultiSearch.ets
@@ -184,7 +184,6 @@ export struct MultiSearch {
     .mode(NavDestinationMode.STANDARD)
     .width(StyleConstants.FULL_WIDTH)
     .height(StyleConstants.FULL_HEIGHT)
-    .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM, LayoutSafeAreaEdge.TOP])
   }
 
   /**

--- a/entry/src/main/ets/view/MultiSearch.ets
+++ b/entry/src/main/ets/view/MultiSearch.ets
@@ -99,7 +99,7 @@ export struct MultiSearch {
                     type: 'Song',
                     title: "歌曲",
                     loading: this.loading,
-                  }).key('search')
+                  })
                 }
                 // 歌单
                 if(this.isNullResult(this.result.playlists)){
@@ -108,7 +108,7 @@ export struct MultiSearch {
                     type: 'Playlist',
                     title: "歌单",
                     loading: this.loading,
-                  }).key('search')
+                  })
                 }
                 // 艺人
                 if(this.isNullResult(this.result.artists)){
@@ -118,7 +118,7 @@ export struct MultiSearch {
                     title: "歌手",
                     loading: this.loading,
                     radius: "100%",
-                  }).key('search')
+                  })
                 }
                 // 专辑
                 if(this.isNullResult(this.result.albums)){
@@ -127,7 +127,7 @@ export struct MultiSearch {
                     type: 'Album',
                     title: "专辑",
                     loading: this.loading,
-                  }).key('search')
+                  })
                 }
                 // 如果结果为空
                 if(this.nullResultFlag){

--- a/entry/src/main/ets/view/Playing.ets
+++ b/entry/src/main/ets/view/Playing.ets
@@ -1734,7 +1734,6 @@ struct Playing {
       .width(StyleConstants.FULL_WIDTH)
       .height(StyleConstants.FULL_HEIGHT)
     }
-    .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM, LayoutSafeAreaEdge.TOP])
     .systemTransition(NavigationSystemTransitionType.FADE)
     .hideToolBar(true)
     .hideTitleBar(true)

--- a/entry/src/main/ets/view/Playing.ets
+++ b/entry/src/main/ets/view/Playing.ets
@@ -1437,10 +1437,10 @@ struct Playing {
       // 歌曲信息
       Column({ space: 4 }) {
         Text(this.song?.name || "未知歌曲")
-          .fontSize(this.getFontSize(this.song?.name ?? "", 24, 24))
+          .fontSize(24)
           .fontWeight(FontWeight.Bold)
           .maxLines(1)
-          .textOverflow({ overflow: TextOverflow.Ellipsis })
+          .textOverflow({ overflow: TextOverflow.MARQUEE })
           .fontColor(Color.White)
           .height(32) // 固定高度确保布局稳定
 
@@ -1448,13 +1448,14 @@ struct Playing {
           .fontSize(16)
           .fontColor('rgba(255, 255, 255, 0.6)')
           .maxLines(1)
-          .textOverflow({ overflow: TextOverflow.Ellipsis })
+          .textOverflow({ overflow: TextOverflow.MARQUEE })
           .height(24) // 固定高度确保布局稳定
       }
       .width(StyleConstants.FULL_WIDTH)
       .layoutWeight(1)
       .alignItems(HorizontalAlign.Center)
       .margin({ top: 16, bottom: 4 })
+      .padding({ left: 12, right: 12 })
       .height(60) // 固定整个信息区的高度
 
       Blank()

--- a/entry/src/main/ets/view/Playlist.ets
+++ b/entry/src/main/ets/view/Playlist.ets
@@ -657,7 +657,7 @@ export struct PlayList {
           value: $r('app.string.download_all_songs'),
           action: () => {
             if (this.playlist?.songs && this.playlist.songs.length > 0) {
-              ToastUtil.showToast("开始下载全部歌曲")
+              ToastUtil.showToast("开始下载全部歌曲", { alignment: Alignment.Bottom, offset: { dx: 0, dy: -this.winHeight/4 } })
               const songs = this.playlist.songs.filter(song => song.privilege.playable)
               SongDownloadManager.batchDownloadSongs(songs)
             }
@@ -747,7 +747,7 @@ export struct PlayList {
           value: $r('app.string.download_all_songs'),
           action: () => {
             if (this.playlist?.songs && this.playlist.songs.length > 0) {
-              ToastUtil.showToast("开始下载全部歌曲")
+              ToastUtil.showToast("开始下载全部歌曲", { alignment: Alignment.Bottom, offset: { dx: 0, dy: -this.winHeight/4 } })
               const songs = this.playlist.songs.filter(song => song.privilege.playable)
               SongDownloadManager.batchDownloadSongs(songs)
             }

--- a/entry/src/main/ets/view/Playlist.ets
+++ b/entry/src/main/ets/view/Playlist.ets
@@ -585,7 +585,6 @@ export struct PlayList {
     .mode(NavDestinationMode.STANDARD)
     .width(StyleConstants.FULL_WIDTH)
     .height(StyleConstants.FULL_HEIGHT)
-    .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM, LayoutSafeAreaEdge.TOP])
   }
 
   @Builder

--- a/entry/src/main/ets/view/Setting.ets
+++ b/entry/src/main/ets/view/Setting.ets
@@ -410,7 +410,7 @@ export struct Setting {
       // 第一页表单
       Column({ space: 16 }) {
         Scroll(){
-          Column(){
+          Column({ space: 16 }){
 
             Column({ space: 8 }) {
               Text($r('app.string.data_source_name'))
@@ -478,6 +478,7 @@ export struct Setting {
             }
           }
         }
+        .scrollBar(BarState.Off)
       }
       .width(StyleConstants.FULL_WIDTH)
       .padding(16)
@@ -527,12 +528,12 @@ export struct Setting {
                 .translate({ x: this.currentStep === 1 ? 0 : '20%' })
                 .animation({ delay: 100, duration: 250, curve: Curve.FastOutSlowIn })
 
-              TextInput({
+              TextArea({
                 placeholder: $r('app.string.please_input_token_credential'),
-                text: this.tokenFromQR || (this.formData.auth?.token || '')
+                text: this.tokenFromQR || (this.formData.auth?.token || ''),
               })
                 .width(StyleConstants.FULL_WIDTH)
-                .type(InputType.Password)
+                .height(80)
                 .onChange((value) => {
                   if (!this.formData.auth) {
                     this.formData.auth = { token: '', signAt: Date.now() }
@@ -566,6 +567,7 @@ export struct Setting {
             .margin({ bottom: 16 })
           }
         }
+        .scrollBar(BarState.Off)
 
       }
       .width(StyleConstants.FULL_WIDTH)
@@ -770,7 +772,6 @@ export struct Setting {
       detents:this.Pura_X? [SheetSize.LARGE]:[SheetSize.MEDIUM],
       preferType: this.currentBreakpoint === BreakpointConstants.BREAKPOINT_SM ? SheetType.BOTTOM : SheetType.CENTER
     })
-    .ignoreLayoutSafeArea([LayoutSafeAreaType.SYSTEM], [LayoutSafeAreaEdge.BOTTOM, LayoutSafeAreaEdge.TOP])
   }
 
   getBlankHeight(): Length {

--- a/entry/src/main/ets/view/Setting.ets
+++ b/entry/src/main/ets/view/Setting.ets
@@ -594,12 +594,13 @@ export struct Setting {
         .onClick(() => {
           DialogUtil.showPrimaryDialog({
             title: $r('app.string.delete_data_source'),
-            message: ResourceManager.getStringValueSync($r('app.string.whether_to_delete_data_source')) +`[${adapter.name}]？`,
+            message: ResourceManager.getStringValueSync($r('app.string.whether_to_delete_data_source')) +`[${adapter.name}]？`+ResourceManager.getStringValueSync($r('app.string.delete_source_desc')),
             primaryButton: $r('app.string.cancel'),
             secondaryButton: $r('app.string.delete'),
             onAction: (action) => {
               if (action == DialogAction.TWO) {
                 PreferencesCache.deleteUserDataSource(adapter.id)
+                PreferencesCache.deleteSongsOfAggregationPlaylists(adapter.id)
                 PreferencesCache.deleteShowUserDataSource(adapter.id)
                 ToastUtil.showShort($r('app.string.data_source_deleted'))
               }

--- a/entry/src/main/ets/viewmodel/SettingGroupData.ets
+++ b/entry/src/main/ets/viewmodel/SettingGroupData.ets
@@ -6,7 +6,7 @@ import { DialogAction, DialogHelper } from "@pura/harmony-dialog";
 import { ResponseCacheUtil } from "../util/ResponseCacheUtil";
 import { SongCacheManager } from "../util/SongCacheManager";
 import ResourceManager from "../util/ResourceManager";
-
+const winHeight: number = AppStorage.get<number>('winHeight') as number
 // 音乐播放设置组
 export const PlayerSetting = [
   // new SettingItem("toggle", $r('app.string.setting_interrupting_continue'), "暂无试验出稳定效果，所以这个只是装饰用",

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -515,6 +515,22 @@
     {
       "name": "delete_source_desc",
       "value": "这将会删除您的聚合歌单中所有属于本数据源的歌曲！！！"
+    },
+    {
+      "name": "playlist_name",
+      "value": "歌单名称"
+    },
+    {
+      "name": "playlist_description",
+      "value": "歌单描述"
+    },
+    {
+      "name": "playlist_name_placeholder",
+      "value": "请输入歌单名称"
+    },
+    {
+      "name": "playlist_desc_placeholder",
+      "value": "请输入歌单描述"
     }
   ]
 }

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -511,6 +511,10 @@
     {
       "name": "delete_song",
       "value": "删除歌曲"
+    },
+    {
+      "name": "delete_source_desc",
+      "value": "这将会删除您的聚合歌单中所有属于本数据源的歌曲！！！"
     }
   ]
 }

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -531,6 +531,14 @@
     {
       "name": "playlist_desc_placeholder",
       "value": "请输入歌单描述"
+    },
+    {
+      "name": "default_playlist_name",
+      "value": "默认歌单"
+    },
+    {
+      "name": "default_playlist_desc",
+      "value": "这是一个本地聚合歌单"
     }
   ]
 }

--- a/entry/src/main/resources/en_US/element/string.json
+++ b/entry/src/main/resources/en_US/element/string.json
@@ -531,6 +531,14 @@
     {
       "name": "playlist_desc_placeholder",
       "value": "Please enter the playlist description"
+    },
+    {
+      "name": "default_playlist_name",
+      "value": "Default Playlist"
+    },
+    {
+      "name": "default_playlist_desc",
+      "value": "This is a local aggregated playlist"
     }
   ]
 }

--- a/entry/src/main/resources/en_US/element/string.json
+++ b/entry/src/main/resources/en_US/element/string.json
@@ -515,6 +515,22 @@
     {
       "name": "delete_source_desc",
       "value": "This will delete all songs from your aggregated playlist that belong to this data source!!!"
+    },
+    {
+      "name": "playlist_name",
+      "value": "Playlist Name"
+    },
+    {
+      "name": "playlist_description",
+      "value": "Playlist Description"
+    },
+    {
+      "name": "playlist_name_placeholder",
+      "value": "Please enter the playlist name"
+    },
+    {
+      "name": "playlist_desc_placeholder",
+      "value": "Please enter the playlist description"
     }
   ]
 }

--- a/entry/src/main/resources/en_US/element/string.json
+++ b/entry/src/main/resources/en_US/element/string.json
@@ -511,6 +511,10 @@
     {
       "name": "delete_song",
       "value": "Delete The Song"
+    },
+    {
+      "name": "delete_source_desc",
+      "value": "This will delete all songs from your aggregated playlist that belong to this data source!!!"
     }
   ]
 }

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -507,6 +507,10 @@
     {
       "name": "delete_song",
       "value": "删除歌曲"
+    },
+    {
+      "name": "delete_source_desc",
+      "value": "这将会删除您的聚合歌单中所有属于本数据源的歌曲！！！"
     }
   ]
 }

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -527,6 +527,14 @@
     {
       "name": "playlist_desc_placeholder",
       "value": "请输入歌单描述"
+    },
+    {
+      "name": "default_playlist_name",
+      "value": "默认歌单"
+    },
+    {
+      "name": "default_playlist_desc",
+      "value": "这是一个本地聚合歌单"
     }
   ]
 }

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -511,6 +511,22 @@
     {
       "name": "delete_source_desc",
       "value": "这将会删除您的聚合歌单中所有属于本数据源的歌曲！！！"
+    },
+    {
+      "name": "playlist_name",
+      "value": "歌单名称"
+    },
+    {
+      "name": "playlist_description",
+      "value": "歌单描述"
+    },
+    {
+      "name": "playlist_name_placeholder",
+      "value": "请输入歌单名称"
+    },
+    {
+      "name": "playlist_desc_placeholder",
+      "value": "请输入歌单描述"
     }
   ]
 }


### PR DESCRIPTION
1. [fix: 解决之前使用复用注解出现首页和搜索页结果的显示重复问题，后续再考虑使用复用注解](https://github.com/Edge-Music/Core/pull/26/commits/47178747752c1e9b66a1da88ad785b44a681774e)
2. [feat: 新增功能，当删除一个数据源时，会删除本地聚合歌单中所有属于本数据源的歌曲](https://github.com/Edge-Music/Core/pull/26/commits/9aa148de5047b1008913a23142c59f38c0e30bd7)
3. [feat: 新增聚合歌单页长按列表呼出菜单](https://github.com/Edge-Music/Core/pull/26/commits/9438e98dfc894ed55118ad70070070ddcf27d3f2)
4. [pref: 暂时把所有存在歌单、歌曲Item的地方，统一Menu，很丑陋，一份代码到处复制，后面再抽象优化](https://github.com/Edge-Music/Core/pull/26/commits/f7504b348cb2bd5d6c4972c7090c70d7d4c11101)
5. [pref: 调整部分Toast位置](https://github.com/Edge-Music/Core/pull/26/commits/31607baaf114ca7ae1a6f0785e142c4fc861dbde)
6. [fix|pref: 修复目前已知问题，优化部分代码](https://github.com/Edge-Music/Core/pull/26/commits/0dbf30ca0c5931612af2fde1eb79deff5638ec3c)
7. [pref: 本地聚合歌单业务逻辑优化](https://github.com/Edge-Music/Core/pull/26/commits/9e120ab7c7d5b80c710c7111b11b350332c2a44c)