### PR TITLE
画中画歌词新增类型选项设置

### DIFF
--- a/entry/src/main/ets/pages/FloatLyrics.ets
+++ b/entry/src/main/ets/pages/FloatLyrics.ets
@@ -3,6 +3,7 @@ import { LogUtil } from "@pura/harmony-utils";
 import { PreferencesCache, SBLyricsPre } from "../util/PreferenceCache";
 import { resourceManager } from "@kit.LocalizationKit";
 import WindowUtil from "../util/WindowUtil";
+import { LyricsLine } from "../util/LyricsManager";
 
 const TAG = 'FloatingLyrics'
 
@@ -12,6 +13,7 @@ export struct FloatingLyrics {
 
   @StorageProp('deviceType') deviceType: resourceManager.DeviceType = resourceManager.DeviceType.DEVICE_TYPE_PHONE
   @StorageLink('test_index') currentLyric: string = '歌词'
+  @StorageLink('current_line_lyrics') currentLineLyric: LyricsLine = new LyricsLine(0, '')
   @StorageProp('SBLyricsSetting') @Watch('onLyricStyleChange') settingData: string = PreferencesCache.getUserPreference('status_bar_lyrics_setting')
   @StorageProp('currentOrientation') @Watch('onLyricStyleChange') currentOrientation: string = 'portrait'
   @StorageProp('displayW') displayW: number = 0
@@ -70,7 +72,7 @@ export struct FloatingLyrics {
 
   build() {
     Stack({ alignContent: Alignment.Center }) {
-      Text(this.currentLyric)
+      Text(this.getShowLyric())
         .textStyle(this.floatLyricStyle)
         .textAlign(this.floatLyricStyle.alignment === 0 ? TextAlign.Center : TextAlign.Start)
         .width('100%')
@@ -80,6 +82,22 @@ export struct FloatingLyrics {
     .backgroundColor(`rgba(255, 255, 255, ${this.floatLyricStyle.transparency})`)
     .height(this.floatLyricStyle.fontSize + 8)
     .animation({ duration: 500, curve: Curve.Smooth })
+  }
+
+  getShowLyric(): string {
+    let result: string = ''
+    switch (this.floatLyricStyle.lyricsType) {
+      case 0:
+        result = this.currentLineLyric.text
+        break;
+      case 1:
+        result = this.currentLineLyric.translation ?? this.currentLineLyric.text
+        break;
+      case 2:
+        result = this.currentLineLyric.transliteration ?? this.currentLineLyric.translation ?? this.currentLineLyric.text
+        break;
+    }
+    return result
   }
 }
 

--- a/entry/src/main/ets/util/LyricsManager.ets
+++ b/entry/src/main/ets/util/LyricsManager.ets
@@ -282,7 +282,7 @@ class LyricsManager {
           if(this.currentIndex !== this.lastIndex){
             this.lastIndex = this.currentIndex
             AppStorage.setOrCreate<LyricsLine>('current_line_lyrics', this.parsedLyrics[this.currentIndex])
-            AppStorage.setOrCreate<string>('test_index', this.parsedLyrics[this.currentIndex].text)
+            this.setPipLyrics()
             AppStorage.setOrCreate<number>('current_lyrics_index', this.currentIndex)
             // FormUtils.updateCardLyricsIndex(this.currentIndex)
             FormUtils.updateCardCurrentLyrics(this.parsedLyrics[this.currentIndex].text)
@@ -299,7 +299,7 @@ class LyricsManager {
           if(this.currentIndex !== this.lastIndex){
             this.lastIndex = this.currentIndex
             AppStorage.setOrCreate<LyricsLine>('current_line_lyrics', this.parsedLyrics[this.currentIndex])
-            AppStorage.setOrCreate<string>('test_index', this.parsedLyrics[this.currentIndex].text)
+            this.setPipLyrics()
             AppStorage.setOrCreate<number>('current_lyrics_index', this.currentIndex)
             // FormUtils.updateCardLyricsIndex(this.currentIndex)
             FormUtils.updateCardCurrentLyrics(this.parsedLyrics[this.currentIndex].text)
@@ -313,6 +313,22 @@ class LyricsManager {
     }
   }
 
+  setPipLyrics() {
+    const lyricsType = parseInt(PreferencesCache.getUserPreference('pip_lyrics_type'))
+    switch (lyricsType) {
+      case 0:
+        AppStorage.setOrCreate<string>('test_index', this.parsedLyrics[this.currentIndex].text)
+        break
+      case 1:
+        AppStorage.setOrCreate<string>('test_index',
+          this.parsedLyrics[this.currentIndex].translation ?? this.parsedLyrics[this.currentIndex].text)
+        break
+      case 2:
+        AppStorage.setOrCreate<string>('test_index',
+          this.parsedLyrics[this.currentIndex].transliteration ?? this.parsedLyrics[this.currentIndex].translation ?? this.parsedLyrics[this.currentIndex].text)
+        break
+    }
+  }
 }
 
 export default new LyricsManager()

--- a/entry/src/main/ets/util/PreferenceCache.ets
+++ b/entry/src/main/ets/util/PreferenceCache.ets
@@ -12,9 +12,10 @@ export interface QualityLevel {
 }
 
 export interface SBLyricsPre{
-  open:boolean;
-  lines:number;
-  alignment:number;
+  open: boolean;
+  lines: number;
+  alignment: number;
+  lyricsType: number;
   x: number;
   y: number;
   width: number;
@@ -594,6 +595,7 @@ export class PreferencesCache {
         open: false,
         lines: 0,
         alignment: 0,
+        lyricsType: 0,
         x: 0,
         y: 0,
         width: display.getDefaultDisplaySync().width/2,

--- a/entry/src/main/ets/view/Personalized_settings.ets
+++ b/entry/src/main/ets/view/Personalized_settings.ets
@@ -12,7 +12,7 @@ export struct Personalized_settings_Component {
   @State setUserPreference_name: string = '';
   // 右侧组件类型：0-Toggle 1-Segment
   @State componentType: number = 0
-  @State lyricTypeIndex: number[] = [parseInt(PreferencesCache.getUserPreference(this.setUserPreference_name))]
+  @State lyricTypeIndex: number[] = []
   private text_ctrl: string = PreferencesCache.getUserPreference(this.setUserPreference_name)
 
   @State lyricsTypeOptions: SegmentButtonOptions = SegmentButtonOptions.tab({
@@ -21,6 +21,10 @@ export struct Personalized_settings_Component {
     selectedBackgroundColor: $r('app.color.title_emphasis_color'),
     fontSize: 12
   })
+
+  aboutToAppear(): void {
+    this.lyricTypeIndex = [parseInt(PreferencesCache.getUserPreference(this.setUserPreference_name, '0'))]
+  }
 
   build() {
     Column(){
@@ -43,10 +47,11 @@ export struct Personalized_settings_Component {
           selectedIndexes: this.lyricTypeIndex,
           onItemClicked:(data: number)=>{
             this.lyricTypeIndex = [data]
-            PreferencesCache.setUserPreference(this.setUserPreference_name, data.toString(0))
+            PreferencesCache.setUserPreference(this.setUserPreference_name, `${data}`)
             AppStorage.setOrCreate(this.setUserPreference_name, data)
           }
         })
+          .visibility(this.componentType === 1 ? Visibility.Visible : Visibility.None)
           .width(180)
           .margin({right:6})
       }
@@ -137,10 +142,10 @@ export struct Personalized_settings{
           ListItem(){ Personalized_settings_Component({text_name: ResourceManager.getStringValueSync($r('app.string.slide_up_hide_title')), setUserPreference_name:'slide_up_hide_title'})}
           ListItem(){ Personalized_settings_Component({text_name: ResourceManager.getStringValueSync($r('app.string.playing_title_show_lyrics')), setUserPreference_name:'playing_title_show_lyrics'})}
           ListItem(){ Personalized_settings_Component({text_name: ResourceManager.getStringValueSync($r('app.string.enable_wave_lyrics')), setUserPreference_name:'enable_wave_lyrics'})}
-          ListItem(){ Personalized_settings_Component({text_name: ResourceManager.getStringValueSync($r('app.string.pip_lyrics_type')), setUserPreference_name:'pip_lyrics_type', componentType: 1})}
           if (deviceInfo.sdkApiVersion>19){
             ListItem(){ Personalized_settings_Component({text_name: '开启流光背景', setUserPreference_name:'UV_background'})}
           }
+          ListItem(){ Personalized_settings_Component({text_name: ResourceManager.getStringValueSync($r('app.string.pip_lyrics_type')), setUserPreference_name:'pip_lyrics_type', componentType: 1})}
 
           ListItem(){ Column().height(16+this.bottomRect/2)}
         }

--- a/entry/src/main/ets/view/Personalized_settings.ets
+++ b/entry/src/main/ets/view/Personalized_settings.ets
@@ -3,13 +3,25 @@ import {HorizontalMode}from '../util/HorizontalCheck'
 import ResourceManager from "../util/ResourceManager";
 import { PipManager } from '../util/PipManager';
 import { deviceInfo } from "@kit.BasicServicesKit";
+import { ItemRestriction, SegmentButton, SegmentButtonOptions, SegmentButtonTextItem } from "@kit.ArkUI";
 
 @Component
   //'0'关。'1'开。!!!!(开关颜色日后调)
 export struct Personalized_settings_Component {
   @State text_name: string = '';
   @State setUserPreference_name: string = '';
-  private text_ctrl:string =  PreferencesCache.getUserPreference(this.setUserPreference_name)
+  // 右侧组件类型：0-Toggle 1-Segment
+  @State componentType: number = 0
+  @State lyricTypeIndex: number[] = [parseInt(PreferencesCache.getUserPreference(this.setUserPreference_name))]
+  private text_ctrl: string = PreferencesCache.getUserPreference(this.setUserPreference_name)
+
+  @State lyricsTypeOptions: SegmentButtonOptions = SegmentButtonOptions.tab({
+    buttons: [{ text: '原词' }, { text: '翻译' }, { text: '罗马音' }] as ItemRestriction<SegmentButtonTextItem>,
+    backgroundBlurStyle: BlurStyle.BACKGROUND_REGULAR,
+    selectedBackgroundColor: $r('app.color.title_emphasis_color'),
+    fontSize: 12
+  })
+
   build() {
     Column(){
       Row(){
@@ -24,6 +36,19 @@ export struct Personalized_settings_Component {
           .onChange((isOn: boolean) => {
             this.onSwitchChangeHandler(isOn)
           })
+          .visibility(this.componentType === 0 ? Visibility.Visible : Visibility.None)
+
+        SegmentButton({
+          options: this.lyricsTypeOptions,
+          selectedIndexes: this.lyricTypeIndex,
+          onItemClicked:(data: number)=>{
+            this.lyricTypeIndex = [data]
+            PreferencesCache.setUserPreference(this.setUserPreference_name, data.toString(0))
+            AppStorage.setOrCreate(this.setUserPreference_name, data)
+          }
+        })
+          .width(180)
+          .margin({right:6})
       }
       .width('100%')
       .justifyContent(FlexAlign.SpaceBetween)
@@ -112,6 +137,7 @@ export struct Personalized_settings{
           ListItem(){ Personalized_settings_Component({text_name: ResourceManager.getStringValueSync($r('app.string.slide_up_hide_title')), setUserPreference_name:'slide_up_hide_title'})}
           ListItem(){ Personalized_settings_Component({text_name: ResourceManager.getStringValueSync($r('app.string.playing_title_show_lyrics')), setUserPreference_name:'playing_title_show_lyrics'})}
           ListItem(){ Personalized_settings_Component({text_name: ResourceManager.getStringValueSync($r('app.string.enable_wave_lyrics')), setUserPreference_name:'enable_wave_lyrics'})}
+          ListItem(){ Personalized_settings_Component({text_name: ResourceManager.getStringValueSync($r('app.string.pip_lyrics_type')), setUserPreference_name:'pip_lyrics_type', componentType: 1})}
           if (deviceInfo.sdkApiVersion>19){
             ListItem(){ Personalized_settings_Component({text_name: '开启流光背景', setUserPreference_name:'UV_background'})}
           }

--- a/entry/src/main/ets/view/SBLyricsSetting.ets
+++ b/entry/src/main/ets/view/SBLyricsSetting.ets
@@ -18,6 +18,7 @@ export struct SBLyricsSetting{
   @State @Watch("onChangeSetting") settingData: SBLyricsPre = PreferencesCache.statusBarLyricsSetting()
   @State linesIndex: number[] = [this.settingData.lines]
   @State alignIndex:number[] = [this.settingData.alignment]
+  @State lyricsTypeIndex:number[] = [this.settingData.lyricsType]
 
   @State linesOptions: SegmentButtonOptions = SegmentButtonOptions.tab({
     buttons: [{ text: '单行' }, { text: '双行' }] as ItemRestriction<SegmentButtonTextItem>,
@@ -27,6 +28,13 @@ export struct SBLyricsSetting{
   })
   @State alignOptions: SegmentButtonOptions = SegmentButtonOptions.tab({
     buttons: [{ text: '居中' }, { text: '居左' }] as ItemRestriction<SegmentButtonTextItem>,
+    backgroundBlurStyle: BlurStyle.BACKGROUND_REGULAR,
+    selectedBackgroundColor: $r('app.color.title_emphasis_color'),
+    fontSize: 12
+  })
+
+  @State lyricsTypeOptions: SegmentButtonOptions = SegmentButtonOptions.tab({
+    buttons: [{ text: '原词' }, { text: '翻译' }, { text: '罗马音' }] as ItemRestriction<SegmentButtonTextItem>,
     backgroundBlurStyle: BlurStyle.BACKGROUND_REGULAR,
     selectedBackgroundColor: $r('app.color.title_emphasis_color'),
     fontSize: 12
@@ -94,25 +102,7 @@ export struct SBLyricsSetting{
 
             Column({ space: 4 }) {
               Column({ space: 12 }) {
-                // Row() {
-                //   Text('展示方式')
-                //     .fontSize(16)
-                //     .fontColor($r('app.color.text_title'))
-                //     .fontWeight(FontWeight.Medium)
-                //   Blank()
-                //     .layoutWeight(1)
-                //   SegmentButton({
-                //     options: this.linesOptions,
-                //     selectedIndexes:this.linesIndex,
-                //     onItemClicked:(data:number)=>{
-                //       this.settingData.lines = data
-                //     }
-                //   })
-                //     .width(120)
-                //     .height(26)
-                //     .margin({right:6})
-                // }
-                // .width(StyleConstants.FULL_WIDTH)
+
                 Row() {
                   Text('对齐方式')
                     .fontSize(16)
@@ -122,12 +112,32 @@ export struct SBLyricsSetting{
                     .layoutWeight(1)
                   SegmentButton({
                     options: this.alignOptions,
-                    selectedIndexes:this.alignIndex,
+                    selectedIndexes: this.alignIndex,
                     onItemClicked:(data:number)=>{
                       this.settingData.alignment = data
                     }
                   })
                     .width(120)
+                    .margin({right:6})
+                }
+                .height(26)
+                .width(StyleConstants.FULL_WIDTH)
+
+                Row() {
+                  Text('歌词展示')
+                    .fontSize(16)
+                    .fontColor($r('app.color.text_title'))
+                    .fontWeight(FontWeight.Medium)
+                  Blank()
+                    .layoutWeight(1)
+                  SegmentButton({
+                    options: this.lyricsTypeOptions,
+                    selectedIndexes: this.lyricsTypeIndex,
+                    onItemClicked:(data: number)=>{
+                      this.settingData.lyricsType = data
+                    }
+                  })
+                    .width(180)
                     .margin({right:6})
                 }
                 .height(26)

--- a/entry/src/main/ets/view/SBLyricsSetting.ets
+++ b/entry/src/main/ets/view/SBLyricsSetting.ets
@@ -17,8 +17,8 @@ export struct SBLyricsSetting{
   @StorageProp('winHeight') winHeight: number = 0
   @State @Watch("onChangeSetting") settingData: SBLyricsPre = PreferencesCache.statusBarLyricsSetting()
   @State linesIndex: number[] = [this.settingData.lines]
-  @State alignIndex:number[] = [this.settingData.alignment]
-  @State lyricsTypeIndex:number[] = [this.settingData.lyricsType]
+  @State alignIndex: number[] = [this.settingData.alignment]
+  @State lyricsTypeIndex: number[] = [this.settingData.lyricsType]
 
   @State linesOptions: SegmentButtonOptions = SegmentButtonOptions.tab({
     buttons: [{ text: '单行' }, { text: '双行' }] as ItemRestriction<SegmentButtonTextItem>,

--- a/entry/src/main/resources/base/element/string.json
+++ b/entry/src/main/resources/base/element/string.json
@@ -723,6 +723,10 @@
     {
       "name": "retry_count",
       "value": "重试中 %s/3"
+    },
+    {
+      "name": "pip_lyrics_type",
+      "value": "画中画歌词类型"
     }
   ]
 }

--- a/entry/src/main/resources/en_US/element/string.json
+++ b/entry/src/main/resources/en_US/element/string.json
@@ -723,6 +723,10 @@
     {
       "name": "download_short",
       "value": "DLs"
+    },
+    {
+      "name": "pip_lyrics_type",
+      "value": "PIP Lyrics Type"
     }
   ]
 }

--- a/entry/src/main/resources/zh_CN/element/string.json
+++ b/entry/src/main/resources/zh_CN/element/string.json
@@ -723,6 +723,10 @@
     {
       "name": "download_short",
       "value": "下载"
+    },
+    {
+      "name": "pip_lyrics_type",
+      "value": "画中画歌词类型"
     }
   ]
 }


### PR DESCRIPTION
1. [feat: 悬浮歌词显示支持切换歌词类型（原歌词，翻译，罗马音）](https://github.com/Edge-Music/Core/commit/f48ab2eab1ae779a6230b93a9c7cd394cfa81e0b)
2. [feat: 画中画歌词类型新增选择项](https://github.com/Edge-Music/Core/commit/2492ec809969aa70ca1d855ce31ba26b9f93cda9)
3. [fix: 修复场景，画中画歌词切换类型，设置展示项错误](https://github.com/Edge-Music/Core/commit/27d72f02a6249942ca6078093e5ca357d2c82dfe)