### PR TITLE
优化桌面悬浮歌词和歌曲卡片样式

### DIFF
--- a/entry/src/main/ets/component/PlaylistItem.ets
+++ b/entry/src/main/ets/component/PlaylistItem.ets
@@ -103,7 +103,7 @@ export struct PlaylistItem {
       .borderRadius(10)
       .backgroundColor(this.getBackgroundColor())
       .backgroundBlurStyle(this.isHovered || this.isPressed ? BlurStyle.COMPONENT_THICK : BlurStyle.NONE)
-      .shadow(ShadowStyle.OUTER_DEFAULT_XS)
+      // .shadow(ShadowStyle.OUTER_DEFAULT_XS)
       .onClick(() => {
         if (this.onPlaylistSelected) {
           this.onPlaylistSelected(this.playlist);

--- a/entry/src/main/ets/component/SongInfo.ets
+++ b/entry/src/main/ets/component/SongInfo.ets
@@ -231,7 +231,6 @@ export struct SongInfo {
           this.rightSlot()
         }
       }
-      .shadow(ShadowStyle.OUTER_DEFAULT_XS)
       .width(StyleConstants.FULL_WIDTH)
       .height(68)
       .padding({ left: 12, right: 12 })

--- a/entry/src/main/ets/pages/FloatLyrics.ets
+++ b/entry/src/main/ets/pages/FloatLyrics.ets
@@ -4,6 +4,7 @@ import { PreferencesCache, SBLyricsPre } from "../util/PreferenceCache";
 import { resourceManager } from "@kit.LocalizationKit";
 import WindowUtil from "../util/WindowUtil";
 import { LyricsLine } from "../util/LyricsManager";
+import { StyleConstants } from "../constants/StyleConstants";
 
 const TAG = 'FloatingLyrics'
 
@@ -11,9 +12,12 @@ const TAG = 'FloatingLyrics'
 @Component
 export struct FloatingLyrics {
 
+  private scroller: Scroller = new Scroller()
   @StorageProp('deviceType') deviceType: resourceManager.DeviceType = resourceManager.DeviceType.DEVICE_TYPE_PHONE
   @StorageLink('test_index') currentLyric: string = '歌词'
   @StorageLink('current_line_lyrics') currentLineLyric: LyricsLine = new LyricsLine(0, '')
+  @StorageLink('current_lyrics_index') @Watch("onTimeUpdate") private currentLyricsIndex: number = 0
+  @StorageProp('current_parsed_lyrics') private parsedLyrics: Array<LyricsLine> = []
   @StorageProp('SBLyricsSetting') @Watch('onLyricStyleChange') settingData: string = PreferencesCache.getUserPreference('status_bar_lyrics_setting')
   @StorageProp('currentOrientation') @Watch('onLyricStyleChange') currentOrientation: string = 'portrait'
   @StorageProp('displayW') displayW: number = 0
@@ -21,6 +25,7 @@ export struct FloatingLyrics {
   @State floatLyricStyle: SBLyricsPre = PreferencesCache.statusBarLyricsSetting()
   private floatWindow: window.Window | undefined
   private uiContext = this.getUIContext()
+  private oldOffsetY: number = this.floatLyricStyle.y
   @State timerID: number = -1
   @State lastShadowStatus: boolean = false
 
@@ -50,7 +55,7 @@ export struct FloatingLyrics {
       return
     }
     const showWidth = this.floatLyricStyle.width*this.displayW-this.uiContext.vp2px(8)
-    const showHeight = this.uiContext.vp2px(this.floatLyricStyle.fontSize+8)
+    const showHeight = this.uiContext.vp2px(this.floatLyricStyle.lines === 0 ? this.floatLyricStyle.fontSize+8 : this.floatLyricStyle.fontSize*2+16)
 
     const offsetX_1 = this.floatLyricStyle.x*this.displayW + this.uiContext.vp2px(4)
     const offsetX_2 = this.floatLyricStyle.x*this.displayW - showWidth - this.uiContext.vp2px(4)
@@ -66,21 +71,38 @@ export struct FloatingLyrics {
       }
     }
     this.floatWindow?.resize(showWidth, showHeight)
-    this.floatWindow?.moveWindowTo(offsetX, offsetY)
+    if(this.oldOffsetY != this.floatLyricStyle.y) {
+      this.floatWindow?.moveWindowTo(offsetX, offsetY)
+      this.oldOffsetY = this.floatLyricStyle.y
+    }
     this.floatWindow?.setWindowCornerRadius(this.floatLyricStyle.cornerRadius)
   }
 
   build() {
-    Stack({ alignContent: Alignment.Center }) {
-      Text(this.getShowLyric())
-        .textStyle(this.floatLyricStyle)
-        .textAlign(this.floatLyricStyle.alignment === 0 ? TextAlign.Center : TextAlign.Start)
-        .width('100%')
+    Stack({ alignContent: Alignment.Top }) {
+      List({
+        initialIndex: this.currentLyricsIndex,
+        scroller: this.scroller,
+        space: 4
+      }) {
+        ForEach(this.parsedLyrics, (item: LyricsLine) => {
+          ListItem(){
+            Text(this.getShowLyricByItem(item))
+              .textStyle(this.floatLyricStyle)
+              .textAlign(this.floatLyricStyle.alignment === 0 ? TextAlign.Center : TextAlign.Start)
+              .width('100%')
+          }
+          .width(StyleConstants.FULL_WIDTH)
+        })
+      }
+      .width(StyleConstants.FULL_WIDTH)
+      .enableScrollInteraction(false)
+      .scrollBar(BarState.Off)
     }
-    .padding({ left: 4, right: 4 })
+    .padding(4)
     .backdropBlur(this.floatLyricStyle.transparency*100)
     .backgroundColor(`rgba(255, 255, 255, ${this.floatLyricStyle.transparency})`)
-    .height(this.floatLyricStyle.fontSize + 8)
+    .height(this.floatLyricStyle.lines === 0 ? this.floatLyricStyle.fontSize+8 : this.floatLyricStyle.fontSize*2+16)
     .animation({ duration: 500, curve: Curve.Smooth })
   }
 
@@ -96,8 +118,36 @@ export struct FloatingLyrics {
       case 2:
         result = this.currentLineLyric.transliteration ?? this.currentLineLyric.translation ?? this.currentLineLyric.text
         break;
+      default:
+        result = this.currentLineLyric.text
+        break;
     }
     return result
+  }
+
+  getShowLyricByItem(item: LyricsLine): string {
+    let result: string = ''
+    switch (this.floatLyricStyle.lyricsType) {
+      case 0:
+        result = item.text
+        break;
+      case 1:
+        result = item.translation ?? item.text
+        break;
+      case 2:
+        result = item.transliteration ?? item.translation ?? item.text
+        break;
+      default:
+        result = item.text
+        break;
+    }
+    return result
+  }
+
+  onTimeUpdate() {
+    if(this.currentLyricsIndex !== -1) {
+      this.scroller.scrollToIndex(this.currentLyricsIndex, true)
+    }
   }
 }
 

--- a/entry/src/main/ets/util/WindowUtil.ets
+++ b/entry/src/main/ets/util/WindowUtil.ets
@@ -250,7 +250,7 @@ class WindowUtil {
       let displayW = display.getDefaultDisplaySync().width;
       let displayH = display.getDefaultDisplaySync().height;
       const showWidth = settingData.width*displayW-uiContext.vp2px(8)
-      const showHeight = uiContext.vp2px(settingData.fontSize+8)
+      const showHeight = uiContext.vp2px(settingData.lines === 0 ? settingData.fontSize+8 : settingData.fontSize*2+16)
       this.lyricsFloatWindow.resize(showWidth, showHeight);
       const offsetX_1 = settingData.x*displayW + uiContext.vp2px(4)
       const offsetX_2 = settingData.x*displayW - showWidth - uiContext.vp2px(4)

--- a/entry/src/main/ets/view/SBLyricsSetting.ets
+++ b/entry/src/main/ets/view/SBLyricsSetting.ets
@@ -104,6 +104,26 @@ export struct SBLyricsSetting{
               Column({ space: 12 }) {
 
                 Row() {
+                  Text('展示方式')
+                    .fontSize(16)
+                    .fontColor($r('app.color.text_title'))
+                    .fontWeight(FontWeight.Medium)
+                  Blank()
+                    .layoutWeight(1)
+                  SegmentButton({
+                    options: this.linesOptions,
+                    selectedIndexes: this.linesIndex,
+                    onItemClicked:(data:number)=>{
+                      this.settingData.lines = data
+                    }
+                  })
+                    .width(120)
+                    .margin({right:6})
+                }
+                .height(26)
+                .width(StyleConstants.FULL_WIDTH)
+
+                Row() {
                   Text('对齐方式')
                     .fontSize(16)
                     .fontColor($r('app.color.text_title'))


### PR DESCRIPTION
1. [pref(style): 去除歌曲列表和歌单列表Item的阴影](https://github.com/Edge-Music/Core/commit/65ddee284d0e286a15e8255bb49ab5877fba70b0)
2. [feat: 桌面歌词新增展示方式为单行or双行；优化桌面歌词动画。](https://github.com/Edge-Music/Core/commit/047f578b28405645bd9f2a047710ab975dee3102)